### PR TITLE
fixed init_tree method

### DIFF
--- a/sitetree/sitetreeapp.py
+++ b/sitetree/sitetreeapp.py
@@ -235,7 +235,7 @@ class SiteTree():
         sitetree_items = self.get_sitetree(tree_alias)
         # No items in tree, fail silently.
         if not sitetree_items:
-            return False
+            return False, False
         return tree_alias, sitetree_items
 
     def get_current_page_title(self, tree_alias, context):


### PR DESCRIPTION
when tree is empty i can't edit it, catch raise in line 323 /sitetree/sitetreeapp.py error Bool not iterable.
that commit fixed this problem
best regards
