### PR TITLE
несмотря на "django.core.context_processors.request" в кон�

### DIFF
--- a/sitetree/templatetags/sitetree.py
+++ b/sitetree/templatetags/sitetree.py
@@ -204,7 +204,7 @@ class sitetree_menuNode(template.Node):
 
     def render(self, context):
         tree_items = sitetree.menu(self.tree_alias, self.tree_branches, context)
-        my_context = template.Context({'sitetree_items': tree_items, 'user': context['user']})
+        my_context = template.Context({'sitetree_items': tree_items, 'user': context['user'], 'request': context['request']})
         return self.template.render(my_context)
 
 


### PR DESCRIPTION
несмотря на "django.core.context_processors.request" в контекст_процессорах - реквест не передается в темплейт тагах (или я чего-то не знаю)
без этого невозможно получить текущий урл и вычислить активность пункта по своей математике (например, /news/?page=3... {% if item.url in request.path %}active{% endif %}
