### PR TITLE
migrations added to manifest

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -5,5 +5,6 @@ include docs/Makefile
 recursive-include docs .rst
 recursive-include docs .py
 recursive-include sitetree/locale *
+recursive-include sitetree/migrations *
 recursive-include sitetree/templates *
 recursive-include sitetree/templatetags *


### PR DESCRIPTION
migrations added to manifest

had an issue with south migrations, noticed, that migrations isn't there while using pip install git+...django-sitetree
