### PR TITLE
Add attribute "is_children" when menu generated by children elements.

### DIFF
--- a/sitetree/sitetreeapp.py
+++ b/sitetree/sitetreeapp.py
@@ -489,7 +489,7 @@ class SiteTree(object):
         tree_items = self.update_has_children(tree_alias, tree_items, navigation_type)
 
         my_template = template.loader.get_template(use_template)
-        context.update({'sitetree_items': tree_items})
+        context.update({'sitetree_items': tree_items, 'is_children': True})
         return my_template.render(context)
 
     def get_children(self, tree_alias, item):


### PR DESCRIPTION
Hello, Igor!

I have two-level menu and standart menu-template:

``` html
{% load sitetree %}
<ul class="main_menu">
    {% for item in sitetree_items %}
    <li>
        <a href="{% sitetree_url for item %}" {% if item.hint %}title="{{ item.hint }}"{% endif %} {% if item.is_current or item.in_current_branch %}class="{{ item.is_current|yesno:"current_item ," }}{{ item.in_current_branch|yesno:"current_branch," }}"{% endif %}>{{ item.title_resolved }}</a>
        {% if item.has_children %}
            {% sitetree_children of item for menu template "sitetree/menu.html" %}
        {% endif %}
    </li>
    {% endfor %}
</ul>
```

How I can say django-sitetree that class "main_menu" need only root-level (level 1) for ul?

``` html
<ul class="main_menu">
    <li>
        lalala
        <ul>
            <li>lalala2</li>
        </ul>
    </li>
</ul>
```

I hope it's possible and I can delete my "bicycle"...
If it's not true - please merge my branch.
Thank's!

UPD:
My new template for class only root-elements:

``` html
{% load sitetree %}
<ul {% if not is_children %}class="main_menu"{% endif %}>
    {% for item in sitetree_items %}
    <li>
        <a href="{% sitetree_url for item %}" {% if item.hint %}title="{{ item.hint }}"{% endif %} {% if item.is_current or item.in_current_branch %}class="{{ item.is_current|yesno:"current_item ," }}{{ item.in_current_branch|yesno:"current_branch," }}"{% endif %}>{{ item.title_resolved }}</a>
        {% if item.has_children %}
            {% sitetree_children of item for menu template "sitetree/menu.html" %}
        {% endif %}
    </li>
    {% endfor %}
</ul>
```
