### PR TITLE
Parse branch_id (=string) to int to make it work

### DIFF
--- a/sitetree/sitetreeapp.py
+++ b/sitetree/sitetreeapp.py
@@ -394,7 +394,7 @@ class SiteTree(object):
                 branch_id = current_item.parent.id
                 parent_ids.append(branch_id)
             elif branch_id.isdigit():
-                parent_ids.append(branch_id)
+                parent_ids.append(int(branch_id))
             else:
                 parent_aliases.append(branch_id)
 


### PR DESCRIPTION
Without the fix it will not validate branch_id as int, and so it's not possible to generate tree directly by id.
