### PR TITLE
Order by parent__sort_order instead of parent

### DIFF
--- a/sitetree/sitetreeapp.py
+++ b/sitetree/sitetreeapp.py
@@ -168,7 +168,7 @@ class SiteTree(object):
         sitetree = self.get_cache_entry('sitetrees', alias)
         if not sitetree:
             sitetree = TreeItem.objects.select_related('parent', 'tree').\
-                   filter(tree__alias__exact=alias).order_by('parent', 'sort_order')
+                   filter(tree__alias__exact=alias).order_by('parent__sort_order', 'sort_order')
             self.set_cache_entry('sitetrees', alias, sitetree)
             sitetree_needs_caching = True
 


### PR DESCRIPTION
Currently get_sitetree does:

order_by('parent', 'sort_order')

When trying to use sitetree_menu to render specific items, we are unable to change the ordering of items, because they are ordered by the parent ID -- something we can't change. That doesn't really make sense to me. This pull request changes the order_by:

order_by('parent__sort_order', 'sort_order')
