### PR TITLE
fix bug in sitetreeload that occurs when using color terminal

### DIFF
--- a/sitetree/management/commands/sitetreeload.py
+++ b/sitetree/management/commands/sitetreeload.py
@@ -4,6 +4,7 @@ from collections import defaultdict
 
 from django.core import serializers
 from django.core.management.base import BaseCommand, CommandError
+from django.core.management.color import no_style
 from django.db import connections, router, transaction, DEFAULT_DB_ALIAS
 from django.core.exceptions import ObjectDoesNotExist
 
@@ -152,7 +153,7 @@ class Command(BaseCommand):
 
         # Reset DB sequences, for DBMS with sequences support.
         if loaded_object_count > 0:
-            sequence_sql = connection.ops.sequence_reset_sql(self.style, [Tree, TreeItem])
+            sequence_sql = connection.ops.sequence_reset_sql(no_style(), [Tree, TreeItem])
             if sequence_sql:
                 self.stdout.write('Resetting DB sequences ...\n')
                 for line in sequence_sql:


### PR DESCRIPTION
видел, что тут пишут по-русски.

столкнулся с удивительной проблемой.
Из-под PyCharm комманда 
sitetreeload --mode=replace fixtures/treedump.json 
отрабатывала прекрасно.

из-под bash получал:
Resetting DB sequences ...
Traceback (most recent call last):
<скип> 
postgresql_psycopg2/base.py", line 52, in execute
    return self.cursor.execute(query, args)
django.db.utils.DatabaseError: syntax error at or near " <-тут рисовался неприличный ироглиф ->"
LINE 1: SELECT setval(pg_get_serial_sequence('"sitetree...

расследование показало, что до базы доходил вот такой select
STATEMENT:  ^[[33mSELECT^[[0m setval(pg_get_serial_sequence('^[[1m"sitetree_tree"^[[0m','^[[32;1m

По-умолчанию DJANGO_COLORS="light"
вместо этого фикса возможно использовать export DJANGO_COLORS="nocolor"
но ИМХО не камильфо
