### PR TITLE
'map' object has no attribute 'append'

### DIFF
--- a/sitetree/templatetags/sitetree.py
+++ b/sitetree/templatetags/sitetree.py
@@ -135,7 +135,7 @@ def sitetree_url(parser, token):
             as_var = tokens[-1]
             tokens = tokens[:-2]
         sitetree_item = parser.compile_filter(tokens[2])
-        tag_arguments = map(parser.compile_filter, tokens[3:])
+        tag_arguments = list(map(parser.compile_filter, tokens[3:]))
         if not tag_arguments:
             tag_arguments = None
         return sitetree_urlNode(sitetree_item, as_var, tag_arguments)


### PR DESCRIPTION
I randomly see this error message and it blows up under Python 3 sometimes. I can't quite recreate the conditions though.
