### PR TITLE
python 3 unicode bugs - replaced u'[string]' by only '[string]'

### DIFF
--- a/sitetree/fields.py
+++ b/sitetree/fields.py
@@ -32,7 +32,7 @@ class TreeItemChoiceField(ChoiceField):
 
     def _build_choices(self):
         """Build choices list runtime using 'sitetree_tree' tag"""
-        tree_token = u'sitetree_tree from "%s" template "%s"' % (self.tree, self.template)
+        tree_token = 'sitetree_tree from "%s" template "%s"' % (self.tree, self.template)
         choices_str = sitetree_tree(template.Parser(None),
                                     template.Token(token_type=template.TOKEN_BLOCK,
                                                    contents=tree_token)).render(template.Context(current_app='admin'))

--- a/sitetree/settings.py
+++ b/sitetree/settings.py
@@ -6,7 +6,7 @@ MODEL_TREE_ITEM = getattr(settings, 'SITETREE_MODEL_TREE_ITEM', 'sitetree.TreeIt
 
 APP_MODULE_NAME = getattr(settings, 'SITETREE_APP_MODULE_NAME', 'sitetrees')
 
-UNRESOLVED_ITEM_MARKER = getattr(settings, 'SITETREE_UNRESOLVED_ITEM_MARKER', u'#unresolved')
+UNRESOLVED_ITEM_MARKER = getattr(settings, 'SITETREE_UNRESOLVED_ITEM_MARKER', '#unresolved')
 
 # Reserved tree items aliases.
 ALIAS_TRUNK = 'trunk'

--- a/sitetree/sitetreeapp.py
+++ b/sitetree/sitetreeapp.py
@@ -389,7 +389,7 @@ class SiteTree(object):
 
                 # Resolve item permissions.
                 if item.access_restricted:
-                    item.perms = set([u'%s.%s' % (perm.content_type.app_label, perm.codename) for perm in
+                    item.perms = set(['%s.%s' % (perm.content_type.app_label, perm.codename) for perm in
                                                item.access_permissions.select_related()])
             # Contextual properties.
             item.url_resolved = self.url(item)
@@ -486,7 +486,7 @@ class SiteTree(object):
             if VERSION >= (1, 5, 0):  # "new-style" url tag - consider sitetree named urls literals.
                 view_path = "'%s'" % view_path
 
-            url_pattern = u'%s %s' % (view_path, ' '.join(all_arguments))
+            url_pattern = '%s %s' % (view_path, ' '.join(all_arguments))
         else:
             url_pattern = str(sitetree_item.url)
 
@@ -503,7 +503,7 @@ class SiteTree(object):
         else:
             if sitetree_item.urlaspattern:
                 # Form token to pass to Django 'url' tag.
-                url_token = u'url %s as item.url_resolved' % url_pattern
+                url_token = 'url %s as item.url_resolved' % url_pattern
                 url_tag(template.Parser(None), template.Token(token_type=template.TOKEN_BLOCK, contents=url_token)).render(context)
 
                 # We make an anchor link from an unresolved URL as a reminder.


### PR DESCRIPTION
Using python 3.2 with django 1.5.
I had the 'invalid syntax' exception while trying to run site tree on my app.
Fixed after replacing classic unicode tags by regular strings
