### PR TITLE
Stops SiteTreeError for TEMPLATE_CONTEXT_PROCESSORS when not DEBUG

### DIFF
--- a/sitetree/sitetreeapp.py
+++ b/sitetree/sitetreeapp.py
@@ -440,7 +440,8 @@ class SiteTree(object):
         current_item = None
 
         if 'request' not in self._global_context:
-            raise SiteTreeError('Sitetree needs "django.core.context_processors.request" to be in TEMPLATE_CONTEXT_PROCESSORS in your settings file. If it is, check that your view pushes request data into the template.')
+            if settings.DEBUG:
+                raise SiteTreeError('Sitetree needs "django.core.context_processors.request" to be in TEMPLATE_CONTEXT_PROCESSORS in your settings file. If it is, check that your view pushes request data into the template.')
         else:
             # urlquote is an attempt to support non-ascii in url.
             current_url = urlquote(self._global_context['request'].path)


### PR DESCRIPTION
Fixes #132 to prevent this error getting thrown in rare logging scenarios
