### PR TITLE
Added option for placehoder TreeItems that do not link to anything.

### DIFF
--- a/sitetree/admin.py
+++ b/sitetree/admin.py
@@ -88,7 +88,7 @@ class TreeItemAdmin(admin.ModelAdmin):
         }),
         (_('Display settings'), {
             'classes': ('collapse',),
-            'fields': ('hidden', 'inmenu', 'inbreadcrumbs', 'insitetree')
+            'fields': ('hidden', 'inmenu', 'inbreadcrumbs', 'insitetree', 'placeholder')
         }),
         (_('Additional settings'), {
             'classes': ('collapse',),

--- a/sitetree/migrations/0002_treeitem_placeholder.py
+++ b/sitetree/migrations/0002_treeitem_placeholder.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('sitetree', '0001_initial'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='treeitem',
+            name='placeholder',
+            field=models.BooleanField(help_text='Whether to show this item without a link, making it a non-clickable placeholder.', verbose_name='Show as placeholder', default=False),
+            preserve_default=True,
+        ),
+    ]

--- a/sitetree/models.py
+++ b/sitetree/models.py
@@ -66,6 +66,7 @@ class TreeItemBase(models.Model):
     inmenu = models.BooleanField(_('Show in menu'), help_text=_('Whether to show this item in a menu.'), db_index=True, default=True)
     inbreadcrumbs = models.BooleanField(_('Show in breadcrumb path'), help_text=_('Whether to show this item in a breadcrumb path.'), db_index=True, default=True)
     insitetree = models.BooleanField(_('Show in site tree'), help_text=_('Whether to show this item in a site tree.'), db_index=True, default=True)
+    placeholder = models.BooleanField(_('Show as placeholder'), help_text=_('Whether to show this item without a link, making it a non-clickable placeholder. You still have to define a URL, but it will be ignored.'), default=False) 
     access_loggedin = models.BooleanField(_('Logged in only'), help_text=_('Check it to grant access to this item to authenticated users only.'), db_index=True, default=False)
     access_guest = models.BooleanField(_('Guests only'), help_text=_('Check it to grant access to this item to guests only.'), db_index=True, default=False)
     access_restricted = models.BooleanField(_('Restrict access to permissions'), help_text=_('Check it to restrict user access to this item, using Django permissions system.'), db_index=True, default=False)

--- a/sitetree/templates/sitetree/breadcrumbs.html
+++ b/sitetree/templates/sitetree/breadcrumbs.html
@@ -5,7 +5,9 @@
 	{% for item in sitetree_items %}
 		{% if not forloop.last %}
 			<li>
+				{% if item.placeholder %}{{ item.title_resolved }}{% else %}
 				<a href="{% sitetree_url for item %}" {% if item.hint %}title="{{ item.hint }}"{% endif %}>{{ item.title_resolved }}</a>
+				{% endif %}
 			</li>
 			<li>&gt;</li>
 		{% else %}

--- a/sitetree/templates/sitetree/menu.html
+++ b/sitetree/templates/sitetree/menu.html
@@ -2,7 +2,11 @@
 <ul>
 	{% for item in sitetree_items %}
 	<li>
+		{% if item.placeholder %}
+		<div class="placeholder{% if item.in_current_branch %} current_branch{% endif %}">{{ item.title_resolved }}</div>
+		{% else %}
         <a href="{% sitetree_url for item %}" {% if item.hint %}title="{{ item.hint }}"{% endif %} {% if item.is_current or item.in_current_branch %}class="{{ item.is_current|yesno:"current_item ," }}{{ item.in_current_branch|yesno:"current_branch," }}"{% endif %}>{{ item.title_resolved }}</a>
+		{% endif %}
 		{% if item.has_children %}
 			{% sitetree_children of item for menu template "sitetree/menu.html" %}
 		{% endif %}


### PR DESCRIPTION
Added option for placehoder TreeItems that do not link to anything.
This allows for items in the tree that appear in breadcrumbs and menus, but do not actually link to anything.

Added placeholder boolean field to ItemTreeBase model.
Altered admin forms to show field.
Altered templates to not renter link if item is placeholder.

See issue #143 for motivation.

One PROBLEM: 
The URL field still requires a value, since I did not feel comfortable adding a null=True to the url field and adding checks depending on item.placeholder in the forms.
So I have added the note in the help_text of the placeholder field saying: A URL is still required, but will be ignored.

Guess that should be quite clear.
