### PR TITLE
clear sitetree cache on startup

### DIFF
--- a/sitetree/config.py
+++ b/sitetree/config.py
@@ -1,4 +1,5 @@
 from django.apps import AppConfig
+from django.core.cache import cache
 from django.utils.translation import ugettext_lazy as _
 
 
@@ -7,3 +8,7 @@ class SitetreeConfig(AppConfig):
 
     name = 'sitetree'
     verbose_name = _('Site Trees')
+
+    def ready(self):
+        cache.delete('sitetrees')
+        cache.delete('tree_aliases')


### PR DESCRIPTION
When redeploying after changing a sitetree, it's often necessary to bust the sitetree cache. This could be automated using the new AppConfig.ready.

I've made the cache clear always, as I didn't see any particular downside in having it doing that.

If you're worried about sites with huge sitetrees, I could make it an optional setting and default it to `False` to preserve old behavior.