### PR TITLE
Adds an IGNORE_ERRORS setting

### DIFF
--- a/docs/source/tags.rst
+++ b/docs/source/tags.rst
@@ -168,3 +168,13 @@ Usage example::
   {% sitetree_page_description from "mytree" %}
 
 This command renders current page description from tree named 'mytree'.
+
+
+
+.. _tag-ignore-errors:
+RAISE_ITEMS_ERRORS_ON_DEBUG
+---------------------------
+
+DEFAULT: True
+
+There are some rare occasions when you want to turn off errors that are thrown by sitetree even during debug. Setting RAISE_ITEMS_ERRORS_ON_DEBUG = False will turn them off.

--- a/sitetree/settings.py
+++ b/sitetree/settings.py
@@ -8,6 +8,8 @@ APP_MODULE_NAME = getattr(settings, 'SITETREE_APP_MODULE_NAME', 'sitetrees')
 
 UNRESOLVED_ITEM_MARKER = getattr(settings, 'SITETREE_UNRESOLVED_ITEM_MARKER', u'#unresolved')
 
+IGNORE_ERRORS = getattr(settings, 'SITETREE_IGNORE_ERRORS', False)
+
 # Reserved tree items aliases.
 ALIAS_TRUNK = 'trunk'
 ALIAS_THIS_CHILDREN = 'this-children'

--- a/sitetree/settings.py
+++ b/sitetree/settings.py
@@ -8,7 +8,7 @@ APP_MODULE_NAME = getattr(settings, 'SITETREE_APP_MODULE_NAME', 'sitetrees')
 
 UNRESOLVED_ITEM_MARKER = getattr(settings, 'SITETREE_UNRESOLVED_ITEM_MARKER', u'#unresolved')
 
-IGNORE_ERRORS = getattr(settings, 'SITETREE_IGNORE_ERRORS', False)
+RAISE_ITEMS_ERRORS_ON_DEBUG = getattr(settings, 'RAISE_ITEMS_ERRORS_ON_DEBUG', True)
 
 # Reserved tree items aliases.
 ALIAS_TRUNK = 'trunk'

--- a/sitetree/sitetreeapp.py
+++ b/sitetree/sitetreeapp.py
@@ -24,7 +24,7 @@ from django.template.defaulttags import url as url_tag
 from .utils import get_tree_model, get_tree_item_model, import_app_sitetree_module, generate_id_for
 from .settings import (
     ALIAS_TRUNK, ALIAS_THIS_CHILDREN, ALIAS_THIS_SIBLINGS, ALIAS_THIS_PARENT_SIBLINGS, ALIAS_THIS_ANCESTOR_CHILDREN,
-    UNRESOLVED_ITEM_MARKER, IGNORE_ERRORS)
+    UNRESOLVED_ITEM_MARKER, RAISE_ITEMS_ERRORS_ON_DEBUG)
 
 
 MODEL_TREE_CLASS = get_tree_model()
@@ -613,7 +613,7 @@ class SiteTree(object):
         current_item = self.get_tree_current_item(tree_alias)
         # Current item is unresolved, fail silently.
         if current_item is None:
-            if settings.DEBUG and not IGNORE_ERRORS:
+            if settings.DEBUG and RAISE_ITEMS_ERRORS_ON_DEBUG:
                 raise SiteTreeError(
                     'Unable to resolve current sitetree item to get a `%s` for current page. Check whether '
                     'there is an appropriate sitetree item defined for current URL.' % attr_name)

--- a/sitetree/sitetreeapp.py
+++ b/sitetree/sitetreeapp.py
@@ -24,7 +24,7 @@ from django.template.defaulttags import url as url_tag
 from .utils import get_tree_model, get_tree_item_model, import_app_sitetree_module, generate_id_for
 from .settings import (
     ALIAS_TRUNK, ALIAS_THIS_CHILDREN, ALIAS_THIS_SIBLINGS, ALIAS_THIS_PARENT_SIBLINGS, ALIAS_THIS_ANCESTOR_CHILDREN,
-    UNRESOLVED_ITEM_MARKER)
+    UNRESOLVED_ITEM_MARKER, IGNORE_ERRORS)
 
 
 MODEL_TREE_CLASS = get_tree_model()
@@ -613,7 +613,7 @@ class SiteTree(object):
         current_item = self.get_tree_current_item(tree_alias)
         # Current item is unresolved, fail silently.
         if current_item is None:
-            if settings.DEBUG:
+            if settings.DEBUG and not IGNORE_ERRORS:
                 raise SiteTreeError(
                     'Unable to resolve current sitetree item to get a `%s` for current page. Check whether '
                     'there is an appropriate sitetree item defined for current URL.' % attr_name)


### PR DESCRIPTION
There are some cases where it is rather annoying to get reminded about missing sitetree items even in a debug environment. This adds a simple SITETREE_IGNORE_ERRORS setting that will not throw the "No resolved sitetree item..." error.