### PR TITLE
Set max length to max 191 to allow utf8mb4 in mysql

### DIFF
--- a/sitetree/models.py
+++ b/sitetree/models.py
@@ -63,10 +63,10 @@ class TreeItemBase(models.Model):
         _('Title'), max_length=100,
         help_text=_('Site tree item title. Can contain template variables E.g.: {{ mytitle }}.'))
     hint = models.CharField(
-        _('Hint'), max_length=200,
+        _('Hint'), max_length=191,
         help_text=_('Some additional information about this item that is used as a hint.'), blank=True, default='')
     url = models.CharField(
-        _('URL'), max_length=200,
+        _('URL'), max_length=191,
         help_text=_('Exact URL or URL pattern (see "Additional settings") for this item.'), db_index=True)
     urlaspattern = models.BooleanField(
         _('URL as Pattern'),


### PR DESCRIPTION
MySQL has internal limitation to 767 bytes. That is 767/4 = 191

Signed-off-by: Roman Rakus <devel@romanrakus.cz>