### PR TITLE
Add extra field to handle get url parameters

### DIFF
--- a/sitetree/admin.py
+++ b/sitetree/admin.py
@@ -84,7 +84,7 @@ class TreeItemAdmin(admin.ModelAdmin):
     exclude = ('tree', 'sort_order')
     fieldsets = (
         (_('Basic settings'), {
-            'fields': ('parent', 'title', 'url',)
+            'fields': ('parent', 'title', 'url', 'url_params',)
         }),
         (_('Access settings'), {
             'classes': ('collapse',),

--- a/sitetree/migrations/0002_treeitem_url_params.py
+++ b/sitetree/migrations/0002_treeitem_url_params.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('sitetree', '0001_initial'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='treeitem',
+            name='url_params',
+            field=models.CharField(help_text='Additional URL parameters (see "Additional settings") for this item.', max_length=200, verbose_name='URL Parameters', db_index=True, blank=True),
+        ),
+    ]

--- a/sitetree/models.py
+++ b/sitetree/models.py
@@ -68,6 +68,9 @@ class TreeItemBase(models.Model):
     url = models.CharField(
         _('URL'), max_length=200,
         help_text=_('Exact URL or URL pattern (see "Additional settings") for this item.'), db_index=True)
+    url_params = models.CharField(
+        _('URL Parameters'), max_length=200,
+        help_text=_('Additional URL parameters (see "Additional settings") for this item.'), blank=True, db_index=True)
     urlaspattern = models.BooleanField(
         _('URL as Pattern'),
         help_text=_('Whether the given URL should be treated as a pattern.<br />'

--- a/sitetree/sitetreeapp.py
+++ b/sitetree/sitetreeapp.py
@@ -582,6 +582,10 @@ class SiteTree(object):
 
             self.update_cache_entry_value('urls', cache_key, {url_pattern: (resolved_url, sitetree_item)})
 
+        # Append optional url_params
+        if sitetree_item.url_params:
+            resolved_url = u'%s?%s' % (resolved_url, sitetree_item.url_params)
+
         return resolved_url
 
     def init_tree(self, tree_alias, context):

--- a/sitetree/south_migrations/0006_auto__add_field_treeitem_url_params.py
+++ b/sitetree/south_migrations/0006_auto__add_field_treeitem_url_params.py
@@ -1,0 +1,68 @@
+# -*- coding: utf-8 -*-
+import datetime
+from south.db import db
+from south.v2 import SchemaMigration
+from django.db import models
+
+
+class Migration(SchemaMigration):
+
+    def forwards(self, orm):
+        # Adding field 'TreeItem.url_params'
+        db.add_column('sitetree_treeitem', 'url_params',
+                      self.gf('django.db.models.fields.CharField')(db_index=True, default='', max_length=200, blank=True),
+                      keep_default=False)
+
+
+    def backwards(self, orm):
+        # Deleting field 'TreeItem.url_params'
+        db.delete_column('sitetree_treeitem', 'url_params')
+
+
+    models = {
+        'auth.permission': {
+            'Meta': {'ordering': "('content_type__app_label', 'content_type__model', 'codename')", 'unique_together': "(('content_type', 'codename'),)", 'object_name': 'Permission'},
+            'codename': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'content_type': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['contenttypes.ContentType']"}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '50'})
+        },
+        'contenttypes.contenttype': {
+            'Meta': {'ordering': "('name',)", 'unique_together': "(('app_label', 'model'),)", 'object_name': 'ContentType', 'db_table': "'django_content_type'"},
+            'app_label': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'model': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '100'})
+        },
+        'sitetree.tree': {
+            'Meta': {'object_name': 'Tree'},
+            'alias': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '80', 'db_index': 'True'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'title': ('django.db.models.fields.CharField', [], {'max_length': '100', 'blank': 'True'})
+        },
+        'sitetree.treeitem': {
+            'Meta': {'unique_together': "(('tree', 'alias'),)", 'object_name': 'TreeItem'},
+            'access_guest': ('django.db.models.fields.BooleanField', [], {'default': 'False', 'db_index': 'True'}),
+            'access_loggedin': ('django.db.models.fields.BooleanField', [], {'default': 'False', 'db_index': 'True'}),
+            'access_perm_type': ('django.db.models.fields.IntegerField', [], {'default': '1'}),
+            'access_permissions': ('django.db.models.fields.related.ManyToManyField', [], {'to': "orm['auth.Permission']", 'symmetrical': 'False', 'blank': 'True'}),
+            'access_restricted': ('django.db.models.fields.BooleanField', [], {'default': 'False', 'db_index': 'True'}),
+            'alias': ('sitetree.models.CharFieldNullable', [], {'db_index': 'True', 'max_length': '80', 'null': 'True', 'blank': 'True'}),
+            'description': ('django.db.models.fields.TextField', [], {'default': "''", 'blank': 'True'}),
+            'hidden': ('django.db.models.fields.BooleanField', [], {'default': 'False', 'db_index': 'True'}),
+            'hint': ('django.db.models.fields.CharField', [], {'default': "''", 'max_length': '200', 'blank': 'True'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'inbreadcrumbs': ('django.db.models.fields.BooleanField', [], {'default': 'True', 'db_index': 'True'}),
+            'inmenu': ('django.db.models.fields.BooleanField', [], {'default': 'True', 'db_index': 'True'}),
+            'insitetree': ('django.db.models.fields.BooleanField', [], {'default': 'True', 'db_index': 'True'}),
+            'parent': ('django.db.models.fields.related.ForeignKey', [], {'blank': 'True', 'related_name': "'treeitem_parent'", 'null': 'True', 'to': "orm['sitetree.TreeItem']"}),
+            'sort_order': ('django.db.models.fields.IntegerField', [], {'default': '0', 'db_index': 'True'}),
+            'title': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'tree': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'treeitem_tree'", 'to': "orm['sitetree.Tree']"}),
+            'url': ('django.db.models.fields.CharField', [], {'max_length': '200', 'db_index': 'True'}),
+            'url_params': ('django.db.models.fields.CharField', [], {'db_index': 'True', 'max_length': '200', 'blank': 'True'}),
+            'urlaspattern': ('django.db.models.fields.BooleanField', [], {'default': 'False', 'db_index': 'True'})
+        }
+    }
+
+    complete_apps = ['sitetree']

--- a/sitetree/templates/admin/sitetree/tree/change_form.html
+++ b/sitetree/templates/admin/sitetree/tree/change_form.html
@@ -40,6 +40,7 @@
 					<th width="1%"><nobr>{% trans "Guests only" %}</nobr></th>
 					<th width="25%">{% trans "Title" %}</th>
 					<th width="20%">{% trans "URL" %}</th>
+					<th width="20%">{% trans "URL Params" %}</th>
 					<th>{% trans "Sort order" %}</th>
 				</tr>
 			</thead>

--- a/sitetree/templates/admin/sitetree/tree/tree.html
+++ b/sitetree/templates/admin/sitetree/tree/tree.html
@@ -23,6 +23,7 @@
             {% if item.is_dynamic %}{{ item.title }}{% else %}<a href="item_{{ item.id }}/">{{ item.title }}</a>{% endif %}
         </td>
 		<td>{{ item.url }}</td>
+		<td>{{ item.url_params }}</td>
 		<td>
 			&nbsp;&nbsp;
 			<a href="item_{{ item.id }}/move_up/" class="ctl arr_up" title="{% trans "Move up" %}"/></a>


### PR DESCRIPTION
This pull request implements an additional field which allows to save get parameters for urls. Those parameters can't be saved in the url parameter, if the url parameter should be resolved by django itself.

Would such a branch have a chance of being merged and what would I need to add to it?