### PR TITLE
Django 1.8. Fixed disappearing tree items for guests in Admin contrib.

### DIFF
--- a/sitetree/admin.py
+++ b/sitetree/admin.py
@@ -14,6 +14,7 @@ from .utils import get_tree_model, get_tree_item_model, get_app_n_model
 
 
 SMUGGLER_INSTALLED = 'smuggler' in django_settings.INSTALLED_APPS
+SUIT_INSTALLED = 'suit' in django_settings.INSTALLED_APPS
 
 MODEL_TREE_CLASS = get_tree_model()
 MODEL_TREE_ITEM_CLASS = get_tree_item_model()
@@ -276,6 +277,9 @@ class TreeAdmin(admin.ModelAdmin):
 
         if SMUGGLER_INSTALLED:
             self.change_list_template = 'admin/sitetree/tree/change_list_.html'
+            
+        if SUIT_INSTALLED:
+            self.change_form_template = 'admin/sitetree/tree/suit/change_form.html'
 
         super(TreeAdmin, self).__init__(*args, **kwargs)
         self.tree_admin = _ITEM_ADMIN()(MODEL_TREE_ITEM_CLASS, admin.site)

--- a/sitetree/sitetreeapp.py
+++ b/sitetree/sitetreeapp.py
@@ -383,10 +383,9 @@ class SiteTree(object):
 
     def current_app_is_admin(self):
         """Returns boolean whether current application is Admin contrib."""
-        current_app = self._global_context.current_app
         if hasattr(self._global_context.get('request', None), 'current_app'):
-            current_app = self._global_context.get('request', None).current_app
-        return current_app == 'admin'
+            return self._global_context['request'].current_app == 'admin'
+        return self._global_context.current_app == 'admin'
 
     def get_sitetree(self, alias):
         """Gets site tree items from the given site tree.

--- a/sitetree/sitetreeapp.py
+++ b/sitetree/sitetreeapp.py
@@ -383,7 +383,7 @@ class SiteTree(object):
 
     def current_app_is_admin(self):
         """Returns boolean whether current application is Admin contrib."""
-        return self._global_context.current_app == 'admin'
+        return self._global_context.get('request', self._global_context).current_app == 'admin'
 
     def get_sitetree(self, alias):
         """Gets site tree items from the given site tree.

--- a/sitetree/sitetreeapp.py
+++ b/sitetree/sitetreeapp.py
@@ -383,7 +383,10 @@ class SiteTree(object):
 
     def current_app_is_admin(self):
         """Returns boolean whether current application is Admin contrib."""
-        return self._global_context.get('request', self._global_context).current_app == 'admin'
+        current_app = self._global_context.current_app
+        if hasattr(self._global_context.get('request', None), 'current_app'):
+            current_app = self._global_context.get('request', None).current_app
+        return current_app == 'admin'
 
     def get_sitetree(self, alias):
         """Gets site tree items from the given site tree.

--- a/sitetree/templates/admin/sitetree/tree/suit/change_form.html
+++ b/sitetree/templates/admin/sitetree/tree/suit/change_form.html
@@ -1,0 +1,44 @@
+{% extends "admin/change_form.html" %}
+{% load i18n admin_list sitetree %}
+
+{% block after_related_objects %}
+{% if change %}
+
+  <div class="module aligned">
+
+  	<h2 class="pull-left" style="bottom: -14px; position: relative;">{% trans "Site Tree Items" %} {{ original.alias }}</h2>
+
+
+    {% if has_add_permission %}
+        <div class="object-tools">
+          <a href="item_add/" class="btn btn-success">
+            <i class="icon-plus-sign icon-white"></i>
+            {% trans "Add Site Tree item" %}
+          </a>
+        </div>
+    {% endif %}
+
+	<div class="module clearfix">
+		<table cellspacing="0" id="result_list" width="100%" class="table table-striped table-bordered table-hover table-condensed">
+			<thead>
+				<tr>
+					<th width="1%">{% trans "Hidden" %}</th>
+					<th width="1%">{% trans "Menu" %}</th>
+					<th width="1%">{% trans "Breadcrumbs" %}</th>
+					<th width="1%">{% trans "Tree" %}</th>
+					<th width="1%"><nobr>{% trans "Restricted" %}</nobr></th>
+					<th width="1%"><nobr>{% trans "Users only" %}</nobr></th>
+					<th width="1%"><nobr>{% trans "Guests only" %}</nobr></th>
+					<th width="25%">{% trans "Title" %}</th>
+					<th width="20%">{% trans "URL" %}</th>
+					<th>{% trans "Sort order" %}</th>
+				</tr>
+			</thead>
+			<tbody>
+				{% sitetree_tree from original.alias template "admin/sitetree/tree/suit/tree.html" %}
+			</tbody>
+		</table>
+	</div>
+  </div>
+{% endif %}
+{% endblock %}

--- a/sitetree/templates/admin/sitetree/tree/suit/tree.html
+++ b/sitetree/templates/admin/sitetree/tree/suit/tree.html
@@ -1,0 +1,34 @@
+{% load i18n sitetree %}
+{% load static %}
+
+{% get_static_prefix as STATIC_URL %}
+
+
+{% for item in sitetree_items %}
+	<tr>
+		<td class="align-center"><img src="{{ STATIC_URL }}admin/img/icon-{{ item.hidden|yesno:"yes,no" }}.gif" alt="{{ item.hidden }}" /></td>
+		<td class="align-center"><img src="{{ STATIC_URL }}admin/img/icon-{{ item.inmenu|yesno:"yes,no" }}.gif" alt="{{ item.inmenu }}" /></td>
+		<td class="align-center"><img src="{{ STATIC_URL }}admin/img/icon-{{ item.inbreadcrumbs|yesno:"yes,no" }}.gif" alt="{{ item.inbreadcrumbs }}" /></td>
+		<td class="align-center"><img src="{{ STATIC_URL }}admin/img/icon-{{ item.insitetree|yesno:"yes,no" }}.gif" alt="{{ item.insitetree }}" /></td>
+		<td class="align-center"><img src="{{ STATIC_URL }}admin/img/icon-{{ item.access_restricted|yesno:"yes,no" }}.gif" alt="{{ item.access_restricted }}" /></td>
+        <td class="align-center"><img src="{{ STATIC_URL }}admin/img/icon-{{ item.access_loggedin|yesno:"yes,no" }}.gif" alt="{{ item.access_loggedin }}" /></td>
+        <td class="align-center"><img src="{{ STATIC_URL }}admin/img/icon-{{ item.access_guest|yesno:"yes,no" }}.gif" alt="{{ item.access_guest }}" /></td>
+		<td>
+            {% for d in item.depth_range %}&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;{% endfor %}
+            {% if item.parent %}|&#8212;{% endif %}
+            {% if item.is_dynamic %}{{ item.title }}{% else %}<a href="item_{{ item.id }}/">{{ item.title }}</a>{% endif %}
+        </td>
+		<td>{{ item.url }}</td>
+		<td>
+            <div class="inline-sortable">
+                <a data-dir="up" class="sortable sortable-up" href="item_{{ item.id }}/move_up/">
+                    <i class="icon-arrow-up icon-alpha5"></i></a>
+                <a data-dir="down" class="sortable sortable-down" href="item_{{ item.id }}/move_down/">
+                    <i class="icon-arrow-down icon-alpha5"></i></a>
+            </div>
+		</td>
+	</tr>
+	{% if item.has_children %}
+		{% sitetree_children of item for sitetree template "admin/sitetree/tree/suit/tree.html" %}
+	{% endif %}
+{% endfor %}


### PR DESCRIPTION
Django 1.8 disappearing menu items in the admin panel if the resolution is only available for guests
https://docs.djangoproject.com/en/1.8/releases/1.8/#current-app-argument-of-template-related-apis