### PR TITLE
Passing global context to tree hook

### DIFF
--- a/sitetree/sitetreeapp.py
+++ b/sitetree/sitetreeapp.py
@@ -723,7 +723,10 @@ class SiteTree(object):
         """
         if _ITEMS_PROCESSOR is None:
             return items
-        return _ITEMS_PROCESSOR(tree_items=items, tree_sender=sender)
+        try:
+            return _ITEMS_PROCESSOR(tree_items=items, tree_sender=sender, global_context=self._global_context)
+        except TypeError:
+            return _ITEMS_PROCESSOR(tree_items=items, tree_sender=sender)
 
     def check_access(self, item, context):
         """Checks whether a current user has an access to a certain item."""


### PR DESCRIPTION
It would be nice if I could filter tree items in hook based on some complicated logic involving user from request.
But current implementation of tree hooks passes only items and sender. Using custom tree item model and passing global context should help in such situations.

I don't know if I could do this any other way.

P.S.: got a little try/except around new call so there should be no backwards-compatibility problems.
