### PR TITLE
Made django-sitetree thread safe

### DIFF
--- a/sitetree/sitetreeapp.py
+++ b/sitetree/sitetreeapp.py
@@ -248,7 +248,7 @@ class LazyTitle(object):
                 my_tokens.remove(my_token)
 
         my_parser = Parser(my_tokens)
-        return my_parser.parse().render(SiteTree.get_global_context())
+        return my_parser.parse().render(self.get_context())
 
     def __eq__(self, other):
         return self.__str__() == other
@@ -316,24 +316,21 @@ class Cache(object):
 
 class SiteTree(object):
 
-    _global_context = Context()
+    context = None
 
     def __init__(self):
         self.cache = Cache()
 
-    @classmethod
-    def set_global_context(cls, context):
+    def set_context(self, context):
         """Saves context as global context if not already set or if changed.
         Almost all variables are resolved against global context.
 
         """
-        if not cls._global_context or id(context) != id(cls._global_context):
-            cls._global_context = context
+        if not self.context or id(context) != id(self.context):
+            self.context = context
 
-    @classmethod
-    def get_global_context(cls):
-        """Returns current sitetree global context."""
-        return cls._global_context
+    def get_context(self):
+        return self.context
 
     def resolve_tree_i18n_alias(self, alias):
         """Resolves internationalized tree alias.
@@ -402,8 +399,8 @@ class SiteTree(object):
     def current_app_is_admin(self):
         """Returns boolean whether current application is Admin contrib."""
         current_app = (
-            getattr(self._global_context.get('request', None), 'current_app',
-                    self._global_context.current_app))
+            getattr(self.get_context().get('request', None), 'current_app',
+                    self.get_context().current_app))
 
         return current_app == 'admin'
 
@@ -506,14 +503,14 @@ class SiteTree(object):
 
         current_item = None
 
-        if 'request' not in self._global_context:
+        if 'request' not in self.get_context():
             if settings.DEBUG:
                 raise SiteTreeError(
                     'Sitetree needs "django.core.context_processors.request" to be in TEMPLATE_CONTEXT_PROCESSORS '
                     'in your settings file. If it is, check that your view pushes request data into the template.')
         else:
             # urlquote is an attempt to support non-ascii in url.
-            current_url = urlquote(self._global_context['request'].path)
+            current_url = urlquote(self.get_context()['request'].path)
             urls_cache = self.cache.get_entry('urls', '%s%s' % (tree_alias, self.lang_get()))
             if urls_cache:
                 for url_item in urls_cache:
@@ -553,7 +550,7 @@ class SiteTree(object):
         """
 
         if context is None:
-            context = self._global_context
+            context = self.get_context()
 
         if not isinstance(sitetree_item, MODEL_TREE_ITEM_CLASS):
             sitetree_item = self.resolve_var(sitetree_item, context)
@@ -623,8 +620,8 @@ class SiteTree(object):
         On fail returns False.
 
         """
-        # Current context we will consider global.
-        self.set_global_context(context)
+        
+        self.set_context(context)
         # Initialize language to use it in current thread.
         self.lang_init()
         # Resolve tree_alias from the context.
@@ -728,7 +725,7 @@ class SiteTree(object):
     def check_access(self, item, context):
         """Checks whether a current user has an access to a certain item."""
 
-        authenticated = self._global_context['request'].user.is_authenticated()
+        authenticated = self.get_context()['request'].user.is_authenticated()
 
         if item.access_loggedin and not authenticated:
             return False
@@ -817,7 +814,7 @@ class SiteTree(object):
         items_out = copy(items)
         if not self.current_app_is_admin():
             for item in items:
-                no_access = not self.check_access(item, self._global_context)
+                no_access = not self.check_access(item, self.get_context())
                 hidden_for_nav_type = navigation_type is not None and not getattr(item, 'in' + navigation_type, False)
                 if item.hidden or no_access or hidden_for_nav_type:
                     items_out.remove(item)
@@ -845,19 +842,19 @@ class SiteTree(object):
     def breadcrumbs_climber(self, tree_alias, start_from):
         """Climbs up the site tree to build breadcrumb path."""
         if start_from.inbreadcrumbs and start_from.hidden == False and self.check_access(start_from,
-                                                                                         self._global_context):
+                                                                                         self.get_context()):
             self.cache_breadcrumbs.append(start_from)
         if hasattr(start_from, 'parent') and start_from.parent is not None:
             self.breadcrumbs_climber(tree_alias, self.get_item_by_id(tree_alias, start_from.parent.id))
 
     def resolve_var(self, varname, context=None):
         """Tries to resolve name as a variable in a given context.
-        If no context specified 'global_context' is considered
+        If no context specified 'self.context' is considered
         as context.
 
         """
         if context is None:
-            context = self._global_context
+            context = self.get_context()
 
         if isinstance(varname, FilterExpression):
             varname = varname.resolve(context)

--- a/sitetree/sitetreeapp.py
+++ b/sitetree/sitetreeapp.py
@@ -47,23 +47,14 @@ _DYNAMIC_TREES = {}
 # Dictionary index in `_DYNAMIC_TREES` for orphaned trees list.
 _IDX_ORPHAN_TREES = 'orphans'
 # Dictinary index name template in `_DYNAMIC_TREES`.
-_IDX_TPL = '%s|:|%s'
-# SiteTree app-wise object.
-_SITETREE = None
+_IDX_TPL = '%s|:|%s' 
 
 _THREAD_LOCAL = local()
 _THREAD_LANG = 'sitetree_lang'
 
 
 def get_sitetree():
-    """Returns SiteTree [singleton] object, implementing utility methods.
-
-    :return: SiteTree
-    """
-    global _SITETREE
-    if _SITETREE is None:
-        _SITETREE = SiteTree()
-    return _SITETREE
+    return SiteTree() 
 
 
 def register_items_hook(callable):

--- a/sitetree/templatetags/sitetree.py
+++ b/sitetree/templatetags/sitetree.py
@@ -6,8 +6,11 @@ from ..sitetreeapp import get_sitetree
 
 register = template.Library()
 
-# All utility methods are implemented in SiteTree class
-sitetree = get_sitetree()
+def sitetree_from_context(context): 
+    if 'sitetree_obj' in context: 
+        return context['sitetree_obj']
+    context['sitetree_obj'] = get_sitetree()
+    return context['sitetree_obj']
 
 
 @register.tag
@@ -163,7 +166,7 @@ class sitetree_treeNode(template.Node):
         self.tree_alias = tree_alias
 
     def render(self, context):
-        tree_items = sitetree.tree(self.tree_alias, context)
+        tree_items = sitetree_from_context(context).tree(self.tree_alias, context)
         return render(context, tree_items, self.use_template or 'sitetree/tree.html')
 
 
@@ -176,7 +179,7 @@ class sitetree_childrenNode(template.Node):
         self.navigation_type = navigation_type
 
     def render(self, context):
-        return sitetree.children(self.tree_item, self.navigation_type, self.use_template.resolve(context), context)
+        return sitetree_from_context(context).children(self.tree_item, self.navigation_type, self.use_template.resolve(context), context)
 
 
 class sitetree_breadcrumbsNode(template.Node):
@@ -187,7 +190,7 @@ class sitetree_breadcrumbsNode(template.Node):
         self.tree_alias = tree_alias
 
     def render(self, context):
-        tree_items = sitetree.breadcrumbs(self.tree_alias, context)
+        tree_items = sitetree_from_context(context).breadcrumbs(self.tree_alias, context)
         return render(context, tree_items, self.use_template or 'sitetree/breadcrumbs.html')
 
 
@@ -200,7 +203,7 @@ class sitetree_menuNode(template.Node):
         self.tree_branches = tree_branches
 
     def render(self, context):
-        tree_items = sitetree.menu(self.tree_alias, self.tree_branches, context)
+        tree_items = sitetree_from_context(context).menu(self.tree_alias, self.tree_branches, context)
         return render(context, tree_items, self.use_template or 'sitetree/menu.html')
 
 
@@ -254,28 +257,28 @@ class sitetree_urlNode(SimpleNode):
     """Resolves and renders specified url."""
 
     def get_value(self, context):
-        return sitetree.url(self.item, context)
+        return sitetree_from_context(context).url(self.item, context)
 
 
 class sitetree_page_titleNode(SimpleNode):
     """Renders a page title from the specified site tree."""
 
     def get_value(self, context):
-        return sitetree.get_current_page_title(self.item, context)
+        return sitetree_from_context(context).get_current_page_title(self.item, context)
 
 
 class sitetree_page_descriptionNode(SimpleNode):
     """Renders a page description from the specified site tree."""
 
     def get_value(self, context):
-        return sitetree.get_current_page_attr('description', self.item, context)
+        return sitetree_from_context(context).get_current_page_attr('description', self.item, context)
 
 
 class sitetree_page_hintNode(SimpleNode):
     """Renders a page hint from the specified site tree."""
 
     def get_value(self, context):
-        return sitetree.get_current_page_attr('hint', self.item, context)
+        return sitetree_from_context(context).get_current_page_attr('hint', self.item, context)
     
 
 def detect_clause(parser, clause_name, tokens):

--- a/sitetree/tests.py
+++ b/sitetree/tests.py
@@ -5,7 +5,7 @@ try:
     from StringIO import StringIO
 except ImportError:
     from io import StringIO
-    
+
 try:
     from unittest import mock
 except ImportError:
@@ -476,7 +476,7 @@ class TemplateTagsTest(SitetreeTest):
     def test_sitetree_children(self):
 
         context = get_mock_context(put_var=self.tree_ttags_root)
-        self.sitetree.set_global_context(context)
+        self.sitetree.set_context(context)
 
         tpl = '{% load sitetree %}{% sitetree_children %}'
         self.assertRaises(TemplateSyntaxError, render_string, tpl)
@@ -590,7 +590,7 @@ class TreeTest(SitetreeTest):
         self.assertEqual(self.t3_en.get_title(), 'tree3en_title')
 
     def test_children_filtering(self):
-        self.sitetree._global_context = get_mock_context(path='/')
+        self.sitetree.context = get_mock_context(path='/')
         self.sitetree.get_sitetree('tree3')
         children = self.sitetree.get_children('tree3', self.t3_root)
         filtered = self.sitetree.filter_items(children, 'menu')
@@ -602,7 +602,7 @@ class TreeTest(SitetreeTest):
 
     def test_register_i18n_trees(self):
         register_i18n_trees(['tree3'])
-        self.sitetree._global_context = get_mock_context(path='/the_same_url/')
+        self.sitetree.context = get_mock_context(path='/the_same_url/')
 
         activate('en')
         self.sitetree.get_sitetree('tree3')
@@ -626,6 +626,7 @@ class DynamicTreeTest(SitetreeTest):
     def test_basic_old_and_new(self):
 
         # Assert no dynamic attached.
+        self.sitetree.context = get_mock_context()
         tree_alias, sitetree_items = self.sitetree.get_sitetree('main')
         self.assertEqual(len(sitetree_items), 1)
 
@@ -683,7 +684,7 @@ class DynamicTreeTest(SitetreeTest):
             register_dynamic_trees(trees, **kwargs)
 
         mock_context = get_mock_context(path='/the_same_url/')
-        self.sitetree._global_context = mock_context
+        self.sitetree.context = mock_context
         tree_alias, sitetree_items = self.sitetree.get_sitetree('main')
 
         if reset_cache:


### PR DESCRIPTION
I remove the global singleton and the global context variable. I'm storing the sitetree class in the context for the request. The first  tag that uses the sitetree will create it. The ones after that will reference the already created sitetree. Everything appears to work for me although you probably will want to go over everything yourself.

If you put some debug statements in create_from_context:

``` python
def sitetree_from_context(context): 
    if 'sitetree_obj' in context:
        print 'Already Exists'
        return context['sitetree_obj']
    context['sitetree_obj'] = get_sitetree()
    print 'Creating tree'
    return context['sitetree_obj']
```

It prints out:

```
Creating tree
Already Exists
Already Exists
Already Exists
Already Exists
Already Exists
Already Exists
Already Exists
Already Exists
Already Exists
Already Exists
Already Exists
Already Exists
Already Exists
Already Exists
Already Exists
Already Exists
Already Exists
Already Exists
Already Exists
Already Exists
Already Exists
Already Exists
Already Exists
Already Exists
Already Exists
Already Exists
Already Exists
Already Exists
Already Exists
Already Exists
Already Exists
Already Exists
Already Exists
```

This seems to follow the same pattern on instantiating the sitetree once per request without storing anything in global variables.
