### PR TITLE
Fix for django regex warning

### DIFF
--- a/sitetree/admin.py
+++ b/sitetree/admin.py
@@ -302,7 +302,7 @@ class TreeAdmin(admin.ModelAdmin):
 
         sitetree_urls = [
             # Ignore urls.W002. Leading slash is in the right place.
-            url(r'^/$', redirects_handler, name=get_tree_item_url_name('changelist')),
+            url(r'^$', redirects_handler, name=get_tree_item_url_name('changelist')),
 
             url(r'^((?P<tree_id>\d+)/)?%sitem_add/$' % prefix_change,
                 self.admin_site.admin_view(self.tree_admin.item_add), name=get_tree_item_url_name('add')),


### PR DESCRIPTION
I am currently getting the following warning while runing django with sitetree:
```
?: (urls.W002) Your URL pattern '^/$' [name='sitetree_treeitem_changelist'] has a regex beginning with a '/'. Remove this slash as it is unnecessary.
```
This change gets rid of the warning