### PR TITLE
Prevent TreeItems from being their own parents.

### DIFF
--- a/sitetree/models.py
+++ b/sitetree/models.py
@@ -125,13 +125,19 @@ class TreeItemBase(models.Model):
         help_text=_('Item position among other site tree items under the same parent.'), db_index=True, default=0)
 
     def save(self, force_insert=False, force_update=False, **kwargs):
-        """We override parent save method to set item's sort order to its' primary
-        key value.
+        """Ensure that item is not its own parent and set proper sort order.
 
         """
         super(TreeItemBase, self).save(force_insert, force_update, **kwargs)
+
+        # Set item's sort order to its primary key.
         if self.sort_order == 0:
             self.sort_order = self.id
+
+        # Ensure that item is not its own parent, since this breaks
+        # the sitetree (and possibly the entire site).
+        if self.parent == self:
+            self.parent = None
             self.save()
 
     class Meta(object):

--- a/sitetree/tests.py
+++ b/sitetree/tests.py
@@ -5,7 +5,7 @@ try:
     from StringIO import StringIO
 except ImportError:
     from io import StringIO
-    
+
 try:
     from unittest import mock
 except ImportError:
@@ -287,6 +287,19 @@ class TreeItemModelTest(SitetreeTest):
         self.assertEqual(ti1.title, 'not_new_root_item')
         ti1.delete()
         self.assertIsNone(ti1.id)
+
+    def test_no_recursive_parents(self):
+        """Verify that treeitems cannot be their own parent."""
+        tree = Tree(alias="mytree")
+        tree.save()
+        tree_item = TreeItem(title="i'm my own grandpa", tree=tree)
+        # This item needs to be saved, otherwise it cannot be set
+        # as a parent.
+        tree_item.save()
+
+        tree_item.parent = tree_item
+        tree_item.save()
+        self.assertNotEqual(tree_item, tree_item.parent)
 
     def test_context_proc_required(self):
         context = Context()


### PR DESCRIPTION
Update TreeItem's `save` method to prevent TreeItems from being set as
their own parents, since this can cause problems.