### PR TITLE
Django 1.10 compatibility fix

### DIFF
--- a/sitetree/sitetreeapp.py
+++ b/sitetree/sitetreeapp.py
@@ -410,11 +410,7 @@ class SiteTree(object):
 
     def current_app_is_admin(self):
         """Returns boolean whether current application is Admin contrib."""
-        current_app = (
-            getattr(self._global_context.get('request', None), 'current_app',
-                    self._global_context.current_app))
-
-        return current_app == 'admin'
+        return self._global_context.get('request').resolver_match.app_name == 'admin'
 
     def get_sitetree(self, alias):
         """Gets site tree items from the given site tree.

--- a/sitetree/sitetreeapp.py
+++ b/sitetree/sitetreeapp.py
@@ -410,7 +410,13 @@ class SiteTree(object):
 
     def current_app_is_admin(self):
         """Returns boolean whether current application is Admin contrib."""
-        return self._global_context.get('request').resolver_match.app_name == 'admin'
+        current_app = ""
+        if hasattr(self._global_context, current_app):
+            current_app = (getattr(self._global_context.get('request', None), 'current_app', 
+                self._global_context.current_app))
+        else:
+            current_app = self._global_context.get('request').resolver_match.app_name
+        return current_app == 'admin'
 
     def get_sitetree(self, alias):
         """Gets site tree items from the given site tree.


### PR DESCRIPTION
As of 1.10, Django does not include a current_app attribute in the RequestContext (see https://docs.djangoproject.com/en/dev/releases/1.10/#removed-features-1-10)