### PR TITLE
Speed-up generating tree with lots of permissions

### DIFF
--- a/sitetree/management/commands/sitetree_resync_apps.py
+++ b/sitetree/management/commands/sitetree_resync_apps.py
@@ -28,7 +28,7 @@ class Command(BaseCommand):
     option_list = get_options()
 
     def add_arguments(self, parser):
-        parser.add_argument('args', metavar='app', nargs='+', help='Application names.')
+        parser.add_argument('args', metavar='app', nargs='*', help='Application names.')
         get_options(parser.add_argument)
 
     def handle(self, *apps, **options):

--- a/sitetree/sitetreeapp.py
+++ b/sitetree/sitetreeapp.py
@@ -450,6 +450,7 @@ class SiteTree(object):
 
         if not sitetree:
             sitetree = MODEL_TREE_ITEM_CLASS.objects.select_related('parent', 'tree').\
+                   prefetch_related('access_permissions__content_type').\
                    filter(tree__alias__exact=alias).order_by('parent__sort_order', 'sort_order')
             sitetree = self.attach_dynamic_tree_items(alias, sitetree)
             set_cache_entry('sitetrees', alias, sitetree)
@@ -481,7 +482,7 @@ class SiteTree(object):
                 if item.access_restricted:
                     permissions_src = (
                         item.permissions if getattr(item, 'is_dynamic', False)
-                        else item.access_permissions.select_related())
+                        else item.access_permissions.all())
 
                     item.perms = set(
                         ['%s.%s' % (perm.content_type.app_label, perm.codename) for perm in permissions_src])


### PR DESCRIPTION
Prefetch related permissions and content types to avoid executing bunch of queries.