### PR TITLE
Made project thread safe, which cache state being maintained across all threads and processes

### DIFF
--- a/sitetree/sitetreeapp.py
+++ b/sitetree/sitetreeapp.py
@@ -65,8 +65,8 @@ def get_sitetree():
     st = getattr(_THREAD_LOCAL, _THREAD_SITETREE, None)
     if st is None:
         st = SiteTree()
+        st.cache.init()
         setattr(_THREAD_LOCAL, _THREAD_SITETREE, st)
-    st.cache.init()
     return st
 
 
@@ -345,6 +345,7 @@ class SiteTree(object):
 
         if not global_context or id(context) != id(global_context):
             global_context = context
+            get_sitetree().cache.init()
             setattr(_THREAD_LOCAL, _THREAD_CONTEXT, context)
 
         return global_context

--- a/sitetree/sitetreeapp.py
+++ b/sitetree/sitetreeapp.py
@@ -1,5 +1,6 @@
 from __future__ import unicode_literals
 
+import time
 import warnings
 
 from collections import defaultdict
@@ -49,24 +50,24 @@ _DYNAMIC_TREES = {}
 _IDX_ORPHAN_TREES = 'orphans'
 # Dictinary index name template in `_DYNAMIC_TREES`.
 _IDX_TPL = '%s|:|%s'
-# SiteTree app-wise object.
-_SITETREE = None
 
 _THREAD_LOCAL = local()
 _THREAD_LANG = 'sitetree_lang'
 _THREAD_CACHE = 'sitetree_cache'
 _THREAD_CONTEXT = 'sitetree_ctx'
-
+_THREAD_SITETREE = 'sitetree_tree'
 
 def get_sitetree():
     """Returns SiteTree [singleton] object, implementing utility methods.
 
     :return: SiteTree
     """
-    global _SITETREE
-    if _SITETREE is None:
-        _SITETREE = SiteTree()
-    return _SITETREE
+    st = getattr(_THREAD_LOCAL, _THREAD_SITETREE, None)
+    if st is None:
+        st = SiteTree()
+        setattr(_THREAD_LOCAL, _THREAD_SITETREE, st)
+    st.cache.init()
+    return st
 
 
 def register_items_hook(callable):
@@ -271,6 +272,7 @@ class Cache(object):
 
     def __init__(self):
         self.cache = None
+        self.created_at = 0
 
         cache_empty = self.empty
         # Listen for signals from the models.
@@ -279,7 +281,6 @@ class Cache(object):
         signals.post_delete.connect(cache_empty, sender=MODEL_TREE_ITEM_CLASS)
         # Listen to the changes in item permissions table.
         signals.m2m_changed.connect(cache_empty, sender=MODEL_TREE_ITEM_CLASS.access_permissions)
-        self.init()
 
     @classmethod
     def reset(cls):
@@ -288,24 +289,22 @@ class Cache(object):
         Could be used to show up tree changes made in a different process.
 
         """
-        cache.set('sitetrees_reset', True)
+        cache.set('sitetrees_reset', int(time.time()))
 
     def init(self):
         """Initializes local cache from Django cache."""
 
         # Drop cache flag set by .reset() method.
-        cache.get('sitetrees_reset') and self.empty()
 
-        cache_ = getattr(_THREAD_LOCAL, _THREAD_CACHE, None)
-        if cache_ is None:
+        reset_time = cache.get('sitetrees_reset', 1)
+        if reset_time > self.created_at:
+            self.cache = None
 
-            cache_ = cache.get(
-                # Init cache dictionary with predefined entries.
-                'sitetrees', {'sitetrees': {}, 'urls': {}, 'parents': {}, 'items_by_ids': {}, 'tree_aliases': {}})
-
-            setattr(_THREAD_LOCAL, _THREAD_CACHE, cache_)
-
-        self.cache = cache_
+        if not self.cache:
+            self.created_at = int(time.time())
+            self.cache = cache.get(
+                    # Init cache dictionary with predefined entries.
+                    'sitetrees', {'sitetrees': {}, 'urls': {}, 'parents': {}, 'items_by_ids': {}, 'tree_aliases': {}})
 
     def save(self):
         """Saves sitetree data to Django cache."""
@@ -313,10 +312,8 @@ class Cache(object):
 
     def empty(self, **kwargs):
         """Empties cached sitetree data."""
-        setattr(_THREAD_LOCAL, _THREAD_CACHE, None)
         cache.delete('sitetrees')
-        cache.delete('sitetrees_reset')
-        self.init()
+        cache.set('sitetrees_reset', int(time.time()))
 
     def get_entry(self, entry_name, key):
         """Returns cache entry parameter value by its name."""

--- a/sitetree/templatetags/sitetree.py
+++ b/sitetree/templatetags/sitetree.py
@@ -6,9 +6,6 @@ from ..sitetreeapp import get_sitetree
 
 register = template.Library()
 
-# All utility methods are implemented in SiteTree class
-sitetree = get_sitetree()
-
 
 @register.tag
 def sitetree_tree(parser, token):
@@ -163,7 +160,7 @@ class sitetree_treeNode(template.Node):
         self.tree_alias = tree_alias
 
     def render(self, context):
-        tree_items = sitetree.tree(self.tree_alias, context)
+        tree_items = get_sitetree().tree(self.tree_alias, context)
         return render(context, tree_items, self.use_template or 'sitetree/tree.html')
 
 
@@ -176,7 +173,7 @@ class sitetree_childrenNode(template.Node):
         self.navigation_type = navigation_type
 
     def render(self, context):
-        return sitetree.children(self.tree_item, self.navigation_type, self.use_template.resolve(context), context)
+        return get_sitetree().children(self.tree_item, self.navigation_type, self.use_template.resolve(context), context)
 
 
 class sitetree_breadcrumbsNode(template.Node):
@@ -187,7 +184,7 @@ class sitetree_breadcrumbsNode(template.Node):
         self.tree_alias = tree_alias
 
     def render(self, context):
-        tree_items = sitetree.breadcrumbs(self.tree_alias, context)
+        tree_items = get_sitetree().breadcrumbs(self.tree_alias, context)
         return render(context, tree_items, self.use_template or 'sitetree/breadcrumbs.html')
 
 
@@ -200,7 +197,7 @@ class sitetree_menuNode(template.Node):
         self.tree_branches = tree_branches
 
     def render(self, context):
-        tree_items = sitetree.menu(self.tree_alias, self.tree_branches, context)
+        tree_items = get_sitetree().menu(self.tree_alias, self.tree_branches, context)
         return render(context, tree_items, self.use_template or 'sitetree/menu.html')
 
 
@@ -254,28 +251,28 @@ class sitetree_urlNode(SimpleNode):
     """Resolves and renders specified url."""
 
     def get_value(self, context):
-        return sitetree.url(self.item, context)
+        return get_sitetree().url(self.item, context)
 
 
 class sitetree_page_titleNode(SimpleNode):
     """Renders a page title from the specified site tree."""
 
     def get_value(self, context):
-        return sitetree.get_current_page_title(self.item, context)
+        return get_sitetree().get_current_page_title(self.item, context)
 
 
 class sitetree_page_descriptionNode(SimpleNode):
     """Renders a page description from the specified site tree."""
 
     def get_value(self, context):
-        return sitetree.get_current_page_attr('description', self.item, context)
+        return get_sitetree().get_current_page_attr('description', self.item, context)
 
 
 class sitetree_page_hintNode(SimpleNode):
     """Renders a page hint from the specified site tree."""
 
     def get_value(self, context):
-        return sitetree.get_current_page_attr('hint', self.item, context)
+        return get_sitetree().get_current_page_attr('hint', self.item, context)
     
 
 def detect_clause(parser, clause_name, tokens):


### PR DESCRIPTION
With these changes each thread instantiates it's copy of the sitetree once. On the first call to get_sitetree() the sitetree will be copied from the cache for future requests. The sitetrees_reset cache key now stores a timestamp of when the sitetree was last changed. A variable on the cache called created_at stores when the cache's internal data was created. When a model is changed and the sitetree cache key is deleted a new timestamp is written to sitetrees_reset in Django's cache. If sitetreees_reset becomes larger than the last time an in memory sitetree was loaded, it's data from the cache is refreshed. 

Existing logic of writing to the cache when sitetree_needs_caching is true is kept the same. The first request that deals with an empty cache will write the new sitetree to django's cache. Subsequent requests on other threads will see that their timestamp is out of date and update their in memory cache from Django.

The sitetree variable in templatetags/sitetree.py could no longer be used. If it was left in place the first thread on a process would put it's sitetree there and all the other threads on that process would use the same variable. All the template tags must call get_sitetree() directly so they can get the sitetree for their thread. 

The cache_ variable on the Cache class does not need to be stored in a thread local. It was removed to be a variable on the Cache instances. The can be donce since the Sitetree class instances, and therefore the Cache instances are thread local now. Other thread local calls can probably be removed and simply tied to the sitetree or cache instances now.

I've tested it extensively and I am running it in production. I will update if there are any issues. Tested on Apache with WSGI using debugging statements and all logic appears to work as intended.