### PR TITLE
Adds support for tree aliases of i18n language codes containing hyphens (see #227)

### DIFF
--- a/docs/source/i18n.rst
+++ b/docs/source/i18n.rst
@@ -31,11 +31,11 @@ Example:
     register_i18n_trees(['my_tree', 'my_another_tree'])
 
     # After that you need to create trees for languages supported
-    # in your project, e.g.: `my_tree_en`, `my_tree_ru`.
+    # in your project, e.g.: `my_tree_en`, `my_tree_ru`, `my_tree_pt-br`.
 
     # Then when we address ``my_tree`` from a template django-sitetree will render
     # an appropriate tree for locale currently active in your project.
     # See ``activate`` function from ``django.utils.translation``
-    # and https://docs.djangoproject.com/en/dev/topics/i18n/internationalization
+    # and https://docs.djangoproject.com/en/dev/topics/i18n/
     # for more information.
 

--- a/sitetree/sitetreeapp.py
+++ b/sitetree/sitetreeapp.py
@@ -388,7 +388,7 @@ class SiteTree(object):
         if alias not in _I18N_TREES:
             return alias
 
-        current_language_code = self.current_lang.replace('_', '-').split('-')[0]
+        current_language_code = self.current_lang
         i18n_tree_alias = '%s_%s' % (alias, current_language_code)
         trees_count = self.cache.get_entry('tree_aliases', i18n_tree_alias)
 

--- a/sitetree/tests/test_templatetags.py
+++ b/sitetree/tests/test_templatetags.py
@@ -42,6 +42,14 @@ def test_i18n(build_tree, render_template_tag, mock_template_context):
         {'alias': 'i18tree_ru'},
         [{'title': 'Заголовок', 'url': '/url_ru/'}],
     )
+    build_tree(
+        {'alias': 'i18tree_pt-br'},
+        [{'title': 'Meu Título', 'url': '/url_pt-br/'}],
+    )
+    build_tree(
+        {'alias': 'i18tree_zh-hans'},
+        [{'title': '我蒂特', 'url': '/url_zh-hans/'}],
+    )
     register_i18n_trees(['i18tree'])
 
     activate('en')
@@ -55,6 +63,18 @@ def test_i18n(build_tree, render_template_tag, mock_template_context):
 
     assert '/url_ru/' in result
     assert 'Заголовок' in result
+
+    activate('pt-br')
+    result = render_template_tag('sitetree', 'sitetree_tree from "i18tree"', mock_template_context())
+
+    assert '/url_pt-br/' in result
+    assert 'Meu Título' in result
+
+    activate('zh-hans')
+    result = render_template_tag('sitetree', 'sitetree_tree from "i18tree"', mock_template_context())
+
+    assert '/url_zh-hans/' in result
+    assert '我蒂特' in result
 
     deactivate_all()
 


### PR DESCRIPTION
Regarding issue #227, I have done these changes. Tests with tox pass with python2.7, but I don't have any python 3 interpreters. 
Creating a tree named _maintree_pt-br_ now works good.