### PR TITLE
Add support for object permissions of TreeItem

### DIFF
--- a/demo/requirements.txt
+++ b/demo/requirements.txt
@@ -1,2 +1,3 @@
 Django==2.1.2
 django-sitetree==1.11
+django-guardian==1.4.9

--- a/demo/settings/settings.py
+++ b/demo/settings/settings.py
@@ -23,8 +23,15 @@ INSTALLED_APPS = [
 
     'sitetree',
 
+    'guardian',
+
     'demo',
 ]
+
+AUTHENTICATION_BACKENDS = (
+    'django.contrib.auth.backends.ModelBackend',  # This is the default.
+    'guardian.backends.ObjectPermissionBackend',
+)
 
 MIDDLEWARE = [
     'django.middleware.security.SecurityMiddleware',

--- a/sitetree/sitetreeapp.py
+++ b/sitetree/sitetreeapp.py
@@ -891,6 +891,9 @@ class SiteTree(object):
 
             if user_perms is _UNSET:
                 user_perms = set(context['user'].get_all_permissions())
+                obj_perms = context['user'].get_all_permissions(item)
+                labeled_obj_perms = {'{}.{}'.format(item._meta.app_label, perm) for perm in obj_perms}
+                user_perms.update(labeled_obj_perms)
                 self._current_user_permissions = user_perms
 
             if item.access_perm_type == MODEL_TREE_ITEM_CLASS.PERM_TYPE_ALL:


### PR DESCRIPTION
In order to try this out please follow these steps:

- `./manage.py migrate`
- Add two users in the shell and make them staff (to be able to use the admin login).
- Restrict access to permissions for one TreeItem and set the Permissions granting access (i.e. to "can view site tree item").
- The admins of django-guardian and django-sitetree clash. So for now assigning the permission has to be done in the shell: Use assign_perm (https://django-guardian.readthedocs.io/en/stable/userguide/assign.html) to give one of the new users the permission ('view_treeitem').
- Now you shouldn't see this item when logged out or as the other new user. The user who was assigned the permission should be able to view it.

Do you know how the naming of those permissions works? Is the app label always a part in the django.auth base permission system? You were writing, that we could make it configurable in the settings. Is there a usecase for being able to change this?