### PR TITLE
django-nav-tree No update since 6 years.

### DIFF
--- a/docs/source/addons.rst
+++ b/docs/source/addons.rst
@@ -4,12 +4,3 @@ Thirdparty addons
 Here are listed addons, helpers, tools that work in a conjunction with SiteTree.
 
 Skip through, maybe you find there something interesting.
-
-
-django-nav-tree
----------------
-
-Application providing a better way to set sitetree item URLs in Django Admin using popup window.
-
-https://github.com/ikresoft/django-nav-tree
-


### PR DESCRIPTION
removed django-nav-tree