### PR TITLE
Changed check_access() to harden user references

### DIFF
--- a/sitetree/sitetreeapp.py
+++ b/sitetree/sitetreeapp.py
@@ -916,7 +916,7 @@ class SiteTree:
             user_perms = self._current_user_permissions
 
             if user_perms is _UNSET:
-                user_perms = self.get_permissions(context['user'], item)
+                user_perms = self.get_permissions(self.current_request.user, item)
                 self._current_user_permissions = user_perms
 
             if item.access_perm_type == MODEL_TREE_ITEM_CLASS.PERM_TYPE_ALL:


### PR DESCRIPTION
Modified it to use the same user reference to retrieve permissions as used earlier in the method to check authentication

Reason: using the context['user'] for the later check can break under certain conditions (ex. template-tags that customize context)