### PR TITLE
Enable the selection of a django cache using a variable

### DIFF
--- a/docs/source/performance.rst
+++ b/docs/source/performance.rst
@@ -39,3 +39,6 @@ To avoid performance hits on large sitetrees try to simplify them, and/or reduce
      Django's default is `Local-memory caching <https://docs.djangoproject.com/en/dev/topics/cache/#local-memory-caching>`_
      that is known not playing well with multiple processes (which will eventually cause sitetree to render navigation
      in different states for different processes), so you're advised to use the other choices.
+
+     You can specify the cache backend to use, setting the SITETREE_CACHE_NAME on the django settings to specify the name 
+     of the cache to use.

--- a/docs/source/thirdparty.rst
+++ b/docs/source/thirdparty.rst
@@ -81,3 +81,23 @@ localize your tree items into different languages. This requires some work thoug
 That's how you made `sitetree` work with `modeltranslation`.
 
 Read `django-modeltranslation` documentation for more information on tuning.
+
+
+django-tenants
+---------------
+
+https://pypi.python.org/pypi/django-tenants/
+
+You should use a custom cache config to make it work, configure something like this on the django cache.
+
+.. code-block:: python
+    CACHES = {
+        ...
+        "sitetree_cache": {
+            "BACKEND": "django.core.cache.backends.dummy.DummyCache",
+            "KEY_FUNCTION": "django_tenants.cache.make_key",
+            "REVERSE_KEY_FUNCTION": "django_tenants.cache.reverse_key",
+        },
+    }
+
+    SITETREE_CACHE_NAME = "sitetree_cache"

--- a/sitetree/settings.py
+++ b/sitetree/settings.py
@@ -34,6 +34,9 @@ Cache is only invalidated on sitetree or sitetree item change.
 
 """
 
+CACHE_NAME: str = getattr(settings, 'SITETREE_CACHE_NAME', 'default')
+"""Sitetree cache name to use (Defined in django CACHES hash)."""
+
 ADMIN_APP_NAME: str = getattr(settings, 'SITETREE_ADMIN_APP_NAME', 'admin')
 """Admin application name. In cases custom admin application is used."""
 

--- a/sitetree/sitetreeapp.py
+++ b/sitetree/sitetreeapp.py
@@ -8,7 +8,7 @@ from typing import Callable, List, Optional, Dict, Union, Sequence, Any, Tuple
 from urllib.parse import quote
 
 from django.conf import settings
-from django.core.cache import cache
+from django.core.cache import caches
 from django.db.models import signals, QuerySet
 from django.template.base import (
     FilterExpression, Lexer, Parser, Token, Variable, VariableDoesNotExist, VARIABLE_TAG_START)
@@ -22,7 +22,7 @@ from .compat import TOKEN_BLOCK, TOKEN_TEXT, TOKEN_VAR
 from .exceptions import SiteTreeError
 from .settings import (
     ALIAS_TRUNK, ALIAS_THIS_CHILDREN, ALIAS_THIS_SIBLINGS, ALIAS_THIS_PARENT_SIBLINGS, ALIAS_THIS_ANCESTOR_CHILDREN,
-    UNRESOLVED_ITEM_MARKER, RAISE_ITEMS_ERRORS_ON_DEBUG, CACHE_TIMEOUT, DYNAMIC_ONLY, ADMIN_APP_NAME, SITETREE_CLS)
+    UNRESOLVED_ITEM_MARKER, RAISE_ITEMS_ERRORS_ON_DEBUG, CACHE_TIMEOUT, CACHE_NAME, DYNAMIC_ONLY, ADMIN_APP_NAME, SITETREE_CLS)
 from .utils import get_tree_model, get_tree_item_model, import_app_sitetree_module, generate_id_for
 
 if False:  # pragma: nocover
@@ -57,6 +57,7 @@ _THREAD_LOCAL = local()
 _THREAD_SITETREE: str = 'sitetree'
 _UNSET = set()  # Sentinel
 
+cache = caches[CACHE_NAME]
 
 def get_sitetree() -> 'SiteTree':
     """Returns SiteTree (thread-singleton) object, implementing utility methods.


### PR DESCRIPTION
This changes allow using a variable on django settings to select witch cache to use.
It fixes some problems using django-sitetree and django-tenants together (maybe related to #114 ?)