### PR TITLE
args should agree with usage in function

### DIFF
--- a/docs/source/customization.rst
+++ b/docs/source/customization.rst
@@ -29,7 +29,7 @@ Example:
     class MySiteTree(SiteTree):
         """Custom tree handler to test deep customization abilities."""
 
-        def apply_hook(self, items, sender):
+        def apply_hook(self, tree_items, sender):
             # Suppose we want to process only menu child items.
             if tree_sender == 'menu.children':
                 # Lets add 'Hooked: ' to resolved titles of every item.


### PR DESCRIPTION
Reading the docs, I noticed that the example function `apply_hook` refers to `tree_items` which does not seem to be in scope. I'm assuming that `items` in the args should have been `tree_items`. 