### PR TITLE
Add default_auto_field to SiteTreeConfig

### DIFF
--- a/sitetree/apps.py
+++ b/sitetree/apps.py
@@ -7,3 +7,4 @@ class SitetreeConfig(AppConfig):
 
     name: str = 'sitetree'
     verbose_name: str = _('Site Trees')
+    default_auto_field = 'django.db.models.AutoField'


### PR DESCRIPTION
Currently there is a pending migration if applications set the DEFAULT_AUTO_FIELD to another value.

Fixes #309