### PR TITLE
Replace removed filter length_is with length

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -25,11 +25,20 @@ jobs:
           - python-version: 3.9
             django-version: 5.0
 
+          - python-version: 3.9
+            django-version: 5.1
+
           - python-version: 3.8
             django-version: 5.0
 
+          - python-version: 3.8
+            django-version: 5.1
+
           - python-version: 3.7
             django-version: 5.0
+
+          - python-version: 3.7
+            django-version: 5.1
 
           - python-version: 3.7
             django-version: 4.0

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -15,7 +15,7 @@ jobs:
       fail-fast: false
       matrix:
         python-version: [3.7, 3.8, 3.9, "3.10", 3.11]
-        django-version: [2.0, 2.1, 2.2, 3.0, 3.1, 3.2, 4.0, 5.0]
+        django-version: [2.0, 2.1, 2.2, 3.0, 3.1, 3.2, 4.0, 5.0, 5.1]
 
         exclude:
 

--- a/AUTHORS
+++ b/AUTHORS
@@ -53,6 +53,7 @@ Ben Finney <https://github.com/bignose-debian>
 witwar <https://github.com/witwar>
 Jon Kiparsky <https://github.com/jonkiparsky>
 Jeffrey de Lange <https://github.com/jgadelange>
+Simon Klein <https://github.com/simklei>
 
 
 Translators

--- a/sitetree/templates/sitetree/breadcrumbs-title.html
+++ b/sitetree/templates/sitetree/breadcrumbs-title.html
@@ -1,3 +1,3 @@
 {% load sitetree %}
-{% if sitetree_items|length_is:"1" %}
+{% if sitetree_items|length == 1 %}
 {% else %}{% for item in sitetree_items %}{{ item.title_resolved }}{% if not forloop.last %} - {% endif %}{% endfor %}{% endif %}

--- a/sitetree/templates/sitetree/breadcrumbs.html
+++ b/sitetree/templates/sitetree/breadcrumbs.html
@@ -1,5 +1,5 @@
 {% load sitetree %}
-{% if sitetree_items|length_is:"1" %}
+{% if sitetree_items|length == 1 %}
 {% else %}
 <ul>
 	{% for item in sitetree_items %}

--- a/sitetree/templates/sitetree/breadcrumbs_bootstrap.html
+++ b/sitetree/templates/sitetree/breadcrumbs_bootstrap.html
@@ -1,5 +1,5 @@
 {% load sitetree %}
-{% if sitetree_items|length_is:"1" %}
+{% if sitetree_items|length == 1 %}
 {% else %}
 <ul class="breadcrumb">
     {% for item in sitetree_items %}

--- a/sitetree/templates/sitetree/breadcrumbs_bootstrap3.html
+++ b/sitetree/templates/sitetree/breadcrumbs_bootstrap3.html
@@ -1,5 +1,5 @@
 {% load sitetree %}
-{% if sitetree_items|length_is:"1" %}
+{% if sitetree_items|length == 1 %}
 {% else %}
 <ul class="breadcrumb">
     {% for item in sitetree_items %}

--- a/sitetree/templates/sitetree/breadcrumbs_bootstrap4.html
+++ b/sitetree/templates/sitetree/breadcrumbs_bootstrap4.html
@@ -1,5 +1,5 @@
 {% load sitetree %}
-{% if sitetree_items|length_is:"1" %}
+{% if sitetree_items|length == 1 %}
 {% else %}
 <nav aria-label="breadcrumb" role="navigation">
     <ol class="breadcrumb">

--- a/sitetree/templates/sitetree/breadcrumbs_foundation.html
+++ b/sitetree/templates/sitetree/breadcrumbs_foundation.html
@@ -1,5 +1,5 @@
 {% load sitetree %}
-{% if sitetree_items|length_is:"1" %}
+{% if sitetree_items|length == 1 %}
 {% else %}
 <ul class="breadcrumbs">
     {% for item in sitetree_items %}

--- a/sitetree/templates/sitetree/breadcrumbs_semantic.html
+++ b/sitetree/templates/sitetree/breadcrumbs_semantic.html
@@ -1,5 +1,5 @@
 {% load sitetree %}
-{% if sitetree_items|length_is:"1" %}
+{% if sitetree_items|length == 1 %}
 {% else %}
 <div class="ui breadcrumb">
     {% for item in sitetree_items %}


### PR DESCRIPTION
Fix incompatibility with Django 5.1 due to use of legacy template filter `length_is`. Update test matrix to include Django 5.1 for compatible Python versions.

Should provide a solution to #320.