### PR TITLE
Pr/overridable templates

### DIFF
--- a/docs/source/templatesmod.rst
+++ b/docs/source/templatesmod.rst
@@ -41,6 +41,22 @@ To customize visual representation of navigation elements you should override th
   5. See :ref:`Advanced SiteTree tags section <tags-advanced>` for clarification on two advanced SiteTree template tags.
 
 
+Adding HTML to menu item titles
+-------------------------------
+
+To add HTML content (such as Font Awesome icons) to menu item titles, you can override the ``title`` block in sitetree templates. Most menu templates now include ``{% block title %}{{ item.title_resolved }}{% endblock title %}`` which allows you to customize how titles are rendered. For semantic menu templates with dropdown functionality, use ``{% block title_dropdown %}`` for parent items and ``{% block title %}`` for regular items. Simply extend the desired template and override the title block to include your custom HTML::
+
+    {% extends "sitetree/menu_bootstrap5.html" %}
+    
+    {% block title %}
+        {{ item.title_resolved|safe }}
+    {% endblock title %}
+
+.. warning::
+
+    **Security Warning**: When using HTML in sitetree titles, always ensure that the content is properly sanitized to prevent cross-site scripting (XSS) attacks. Only use the ``|safe`` filter when you are certain that the content is trusted and does not contain malicious code. In systems where users have access to edit sitetree items, consider implementing additional validation or sanitization of HTML content before storage.
+
+
 Templates for Foundation Framework
 ----------------------------------
 

--- a/sitetree/templates/sitetree/menu.html
+++ b/sitetree/templates/sitetree/menu.html
@@ -2,7 +2,9 @@
 <ul>
 	{% for item in sitetree_items %}
 	<li>
-        <a href="{% sitetree_url for item %}" {% if item.hint %}title="{{ item.hint }}"{% endif %} {% if item.is_current or item.in_current_branch %}class="{{ item.is_current|yesno:"current_item ," }}{{ item.in_current_branch|yesno:"current_branch," }}"{% endif %}>{{ item.title_resolved }}</a>
+        <a href="{% sitetree_url for item %}" {% if item.hint %}title="{{ item.hint }}"{% endif %} {% if item.is_current or item.in_current_branch %}class="{{ item.is_current|yesno:"current_item ," }}{{ item.in_current_branch|yesno:"current_branch," }}"{% endif %}>
+            {% block title %}{{ item.title_resolved }}{% endblock title %}
+        </a>
 		{% if item.has_children %}
 			{% sitetree_children of item for menu template "sitetree/menu.html" %}
 		{% endif %}

--- a/sitetree/templates/sitetree/menu_bootstrap.html
+++ b/sitetree/templates/sitetree/menu_bootstrap.html
@@ -3,7 +3,7 @@
     {% for item in sitetree_items %}
         <li class="{% if item.has_children %}dropdown{% endif %} {% if item.is_current or item.in_current_branch %}active{% endif %}">
             <a href="{% if item.has_children %}#{% else %}{% sitetree_url for item %}{% endif %}" {% if item.has_children %}class="dropdown-toggle" data-toggle="dropdown"{% endif %}>
-                {{ item.title_resolved }}
+                {% block title %}{{ item.title_resolved }}{% endblock title %}
                 {% if item.has_children %}<b class="caret"></b>{% endif %}
             </a>
             {% if item.has_children %}

--- a/sitetree/templates/sitetree/menu_bootstrap3.html
+++ b/sitetree/templates/sitetree/menu_bootstrap3.html
@@ -3,7 +3,7 @@
     {% for item in sitetree_items %}
         <li class="{% if item.has_children %}dropdown{% endif %} {% if item.is_current or item.in_current_branch %}active{% endif %}">
             <a href="{% if item.has_children %}#{% else %}{% sitetree_url for item %}{% endif %}" {% if item.has_children %}class="dropdown-toggle" data-toggle="dropdown"{% endif %}>
-                {{ item.title_resolved }}
+                {% block title %}{{ item.title_resolved }}{% endblock title %}
                 {% if item.has_children %}<b class="caret"></b>{% endif %}
             </a>
             {% if item.has_children %}

--- a/sitetree/templates/sitetree/menu_bootstrap3_deep.html
+++ b/sitetree/templates/sitetree/menu_bootstrap3_deep.html
@@ -3,7 +3,7 @@
     {% for item in sitetree_items %}
         <li class="{% if item.has_children %}dropdown{% endif %} {% if item.is_current or item.in_current_branch %}active{% endif %}">
             <a href="{% if item.has_children %}#{% else %}{% sitetree_url for item %}{% endif %}" {% if item.has_children %}class="dropdown-toggle" data-toggle="dropdown"{% endif %}>
-                {{ item.title_resolved }}
+                {% block title %}{{ item.title_resolved }}{% endblock title %}
                 {% if item.has_children %}<b class="caret"></b>{% endif %}
             </a>
             {% if item.has_children %}

--- a/sitetree/templates/sitetree/menu_bootstrap3_deep_dropdown.html
+++ b/sitetree/templates/sitetree/menu_bootstrap3_deep_dropdown.html
@@ -2,7 +2,9 @@
 <ul class="dropdown-menu" role="menu">
     {% for item in sitetree_items %}
        <li role="presentation" class="{% if item.has_children %}dropdown-submenu{% endif %} {% if item.is_current or item.in_current_branch %}active{% endif %}">
-            <a role="menuitem" href="{% sitetree_url for item %}" {% if item.hint %}title="{{ item.hint }}"{% endif %}>{{ item.title_resolved }}</a>
+            <a role="menuitem" href="{% sitetree_url for item %}" {% if item.hint %}title="{{ item.hint }}"{% endif %}>
+                {% block title %}{{ item.title_resolved }}{% endblock title %}
+            </a>
             {% if item.has_children %}
                 {% sitetree_children of item for menu template "sitetree/menu_bootstrap3_dropdown.html" %}
             {% endif %}

--- a/sitetree/templates/sitetree/menu_bootstrap3_dropdown.html
+++ b/sitetree/templates/sitetree/menu_bootstrap3_dropdown.html
@@ -2,7 +2,9 @@
 <ul class="dropdown-menu" role="menu">
     {% for item in sitetree_items %}
         <li role="presentation" {% if item.is_current or item.in_current_branch %}class="active"{% endif %}>
-            <a role="menuitem" href="{% sitetree_url for item %}" {% if item.hint %}title="{{ item.hint }}"{% endif %}>{{ item.title_resolved }}</a>
+            <a role="menuitem" href="{% sitetree_url for item %}" {% if item.hint %}title="{{ item.hint }}"{% endif %}>
+                {% block title %}{{ item.title_resolved }}{% endblock title %}
+            </a>
         </li>
     {% endfor %}
 </ul>

--- a/sitetree/templates/sitetree/menu_bootstrap3_navpills-stacked.html
+++ b/sitetree/templates/sitetree/menu_bootstrap3_navpills-stacked.html
@@ -2,7 +2,9 @@
 <ul class="nav nav-pills nav-stacked">
     {% for item in sitetree_items %}
         <li {% if item.is_current or item.in_current_branch %}class="active"{% endif %}>
-            <a href="{% sitetree_url for item %}">{{ item.title_resolved }}</a>
+            <a href="{% sitetree_url for item %}">
+                {% block title %}{{ item.title_resolved }}{% endblock title %}
+            </a>
         </li>
     {% endfor %}
 </ul>

--- a/sitetree/templates/sitetree/menu_bootstrap3_navpills.html
+++ b/sitetree/templates/sitetree/menu_bootstrap3_navpills.html
@@ -2,7 +2,9 @@
 <ul class="nav nav-pills">
     {% for item in sitetree_items %}
         <li {% if item.is_current or item.in_current_branch %}class="active"{% endif %}>
-            <a href="{% sitetree_url for item %}">{{ item.title_resolved }}</a>
+            <a href="{% sitetree_url for item %}">
+                {% block title %}{{ item.title_resolved }}{% endblock title %}
+            </a>
         </li>
     {% endfor %}
 </ul>

--- a/sitetree/templates/sitetree/menu_bootstrap4.html
+++ b/sitetree/templates/sitetree/menu_bootstrap4.html
@@ -3,7 +3,7 @@
     {% for item in sitetree_items %}
         <li class="nav-item {% if item.has_children %}dropdown{% endif %}">
             <a href="{% if item.has_children %}#{% else %}{% sitetree_url for item %}{% endif %}" class="nav-link {% if item.is_current or item.in_current_branch %}active{% endif %} {% if item.has_children %}dropdown-toggle" aria-haspopup="true" id="navitem-{{ item.id }}" data-toggle="dropdown{% endif %}">
-                {{ item.title_resolved }}
+                {% block title %}{{ item.title_resolved }}{% endblock title %}
             </a>
             {% if item.has_children %}
                 {% sitetree_children of item for menu template "sitetree/menu_bootstrap4_dropdown.html" %}

--- a/sitetree/templates/sitetree/menu_bootstrap4_dropdown.html
+++ b/sitetree/templates/sitetree/menu_bootstrap4_dropdown.html
@@ -1,6 +1,8 @@
 {% load sitetree %}
 <div class="dropdown-menu" aria-labelledby="navitem-{{ item.id }}">
     {% for item in sitetree_items %}
-        <a class="dropdown-item {% if item.is_current or item.in_current_branch %}active{% endif %}" href="{% sitetree_url for item %}" {% if item.hint %}title="{{ item.hint }}"{% endif %}>{{ item.title_resolved }}</a>
+        <a class="dropdown-item {% if item.is_current or item.in_current_branch %}active{% endif %}" href="{% sitetree_url for item %}" {% if item.hint %}title="{{ item.hint }}"{% endif %}>
+            {% block title %}{{ item.title_resolved }}{% endblock title %}
+        </a>
     {% endfor %}
 </div>

--- a/sitetree/templates/sitetree/menu_bootstrap4_navpills-stacked.html
+++ b/sitetree/templates/sitetree/menu_bootstrap4_navpills-stacked.html
@@ -2,7 +2,9 @@
 <ul class="nav nav-pills flex-column">
     {% for item in sitetree_items %}
         <li class="nav-item">
-            <a class="nav-link {% if item.is_current or item.in_current_branch %}active{% endif %}" href="{% sitetree_url for item %}">{{ item.title_resolved }}</a>
+            <a class="nav-link {% if item.is_current or item.in_current_branch %}active{% endif %}" href="{% sitetree_url for item %}">
+                {% block title %}{{ item.title_resolved }}{% endblock title %}
+            </a>
         </li>
     {% endfor %}
 </ul>

--- a/sitetree/templates/sitetree/menu_bootstrap4_navpills.html
+++ b/sitetree/templates/sitetree/menu_bootstrap4_navpills.html
@@ -2,7 +2,9 @@
 <ul class="nav nav-pills">
     {% for item in sitetree_items %}
         <li class="nav-item">
-            <a class="nav-link {% if item.is_current or item.in_current_branch %}active{% endif %}" href="{% sitetree_url for item %}">{{ item.title_resolved }}</a>
+            <a class="nav-link {% if item.is_current or item.in_current_branch %}active{% endif %}" href="{% sitetree_url for item %}">
+                {% block title %}{{ item.title_resolved }}{% endblock title %}
+            </a>
         </li>
     {% endfor %}
 </ul>

--- a/sitetree/templates/sitetree/menu_bootstrap5.html
+++ b/sitetree/templates/sitetree/menu_bootstrap5.html
@@ -3,7 +3,7 @@
     {% for item in sitetree_items %}
         <li class="nav-item {% if item.has_children %}dropdown{% endif %}">
             <a href="{% if item.has_children %}#{% else %}{% sitetree_url for item %}{% endif %}" class="nav-link {% if item.is_current or item.in_current_branch %}active{% endif %} {% if item.has_children %}dropdown-toggle" aria-haspopup="true" id="navitem-{{ item.id }}" data-bs-toggle="dropdown{% endif %}">
-                {{ item.title_resolved }}
+                {% block title %}{{ item.title_resolved }}{% endblock title %}
             </a>
             {% if item.has_children %}
                 {% sitetree_children of item for menu template "sitetree/menu_bootstrap5_dropdown.html" %}

--- a/sitetree/templates/sitetree/menu_bootstrap5_dropdown.html
+++ b/sitetree/templates/sitetree/menu_bootstrap5_dropdown.html
@@ -1,6 +1,8 @@
 {% load sitetree %}
 <div class="dropdown-menu" aria-labelledby="navitem-{{ item.id }}">
     {% for item in sitetree_items %}
-        <a class="dropdown-item {% if item.is_current or item.in_current_branch %}active{% endif %}" href="{% sitetree_url for item %}" {% if item.hint %}title="{{ item.hint }}"{% endif %}>{{ item.title_resolved }}</a>
+        <a class="dropdown-item {% if item.is_current or item.in_current_branch %}active{% endif %}" href="{% sitetree_url for item %}" {% if item.hint %}title="{{ item.hint }}"{% endif %}>
+            {% block title %}{{ item.title_resolved }}{% endblock title %}
+        </a>
     {% endfor %}
 </div>

--- a/sitetree/templates/sitetree/menu_bootstrap_dropdown.html
+++ b/sitetree/templates/sitetree/menu_bootstrap_dropdown.html
@@ -2,7 +2,9 @@
 <ul class="dropdown-menu">
     {% for item in sitetree_items %}
         <li {% if item.is_current or item.in_current_branch %}class="active"{% endif %}>
-            <a href="{% sitetree_url for item %}" {% if item.hint %}title="{{ item.hint }}"{% endif %}>{{ item.title_resolved }}</a>
+            <a href="{% sitetree_url for item %}" {% if item.hint %}title="{{ item.hint }}"{% endif %}>
+                {% block title %}{{ item.title_resolved }}{% endblock title %}
+            </a>
         </li>
     {% endfor %}
 </ul>

--- a/sitetree/templates/sitetree/menu_bootstrap_navlist.html
+++ b/sitetree/templates/sitetree/menu_bootstrap_navlist.html
@@ -2,7 +2,9 @@
 <ul class="nav nav-list">
     {% for item in sitetree_items %}
         <li {% if item.is_current or item.in_current_branch %}class="active"{% endif %}>
-            <a href="{% sitetree_url for item %}">{{ item.title_resolved }}</a>
+            <a href="{% sitetree_url for item %}">
+                {% block title %}{{ item.title_resolved }}{% endblock title %}
+            </a>
         </li>
     {% endfor %}
 </ul>

--- a/sitetree/templates/sitetree/menu_foundation-vertical.html
+++ b/sitetree/templates/sitetree/menu_foundation-vertical.html
@@ -2,7 +2,9 @@
 <ul class="nav-bar vertical">
 	{% for item in sitetree_items %}
 	<li class="{% if item.is_current or item.in_current_branch %}active{% endif %} {% if item.has_children %}has-flyout{% endif %}">
-        <a href="{% if item.has_children %}#{% else %}{% sitetree_url for item %}{% endif %}">{{ item.title_resolved }}</a>
+        <a href="{% if item.has_children %}#{% else %}{% sitetree_url for item %}{% endif %}">
+            {% block title %}{{ item.title_resolved }}{% endblock title %}
+        </a>
 		{% if item.has_children %}
             <a href="#" class="flyout-toggle"><span> </span></a>
 			{% sitetree_children of item for menu template "sitetree/menu_foundation_flyout.html" %}

--- a/sitetree/templates/sitetree/menu_foundation.html
+++ b/sitetree/templates/sitetree/menu_foundation.html
@@ -2,7 +2,9 @@
 <ul class="nav-bar {{ extra_class_ul }}">
 	{% for item in sitetree_items %}
 	<li class="{% if item.is_current or item.in_current_branch %}active{% endif %} {% if item.has_children %}has-flyout{% endif %}">
-        <a href="{% if item.has_children %}#{% else %}{% sitetree_url for item %}{% endif %}">{{ item.title_resolved }}</a>
+        <a href="{% if item.has_children %}#{% else %}{% sitetree_url for item %}{% endif %}">
+            {% block title %}{{ item.title_resolved }}{% endblock title %}
+        </a>
 		{% if item.has_children %}
             <a href="#" class="flyout-toggle"><span> </span></a>
 			{% sitetree_children of item for menu template "sitetree/menu_foundation_flyout.html" %}

--- a/sitetree/templates/sitetree/menu_foundation_flyout.html
+++ b/sitetree/templates/sitetree/menu_foundation_flyout.html
@@ -2,7 +2,9 @@
 <ul class="flyout">
 	{% for item in sitetree_items %}
 	<li {% if item.is_current or item.in_current_branch %}class="active"{% endif %}>
-        <a href="{% sitetree_url for item %}" {% if item.hint %}title="{{ item.hint }}"{% endif %}>{{ item.title_resolved }}</a>
+        <a href="{% sitetree_url for item %}" {% if item.hint %}title="{{ item.hint }}"{% endif %}>
+            {% block title %}{{ item.title_resolved }}{% endblock title %}
+        </a>
 	</li>
 	{% endfor %}
 </ul>

--- a/sitetree/templates/sitetree/menu_foundation_sidenav.html
+++ b/sitetree/templates/sitetree/menu_foundation_sidenav.html
@@ -2,7 +2,9 @@
 <ul class="side-nav">
 	{% for item in sitetree_items %}
 	<li {% if item.is_current or item.in_current_branch %}class="active"{% endif %}>
-        <a href="{% sitetree_url for item %}">{{ item.title_resolved }}</a>
+        <a href="{% sitetree_url for item %}">
+            {% block title %}{{ item.title_resolved }}{% endblock title %}
+        </a>
 	</li>
 	{% endfor %}
 </ul>

--- a/sitetree/templates/sitetree/menu_semantic-vertical.html
+++ b/sitetree/templates/sitetree/menu_semantic-vertical.html
@@ -2,11 +2,15 @@
 <div class="ui fluid vertical menu">
     {% for item in sitetree_items %}
         {% if item.has_children %}
-            <div class="ui dropdown {% if item.is_current or item.in_current_branch %}active{% endif %} item">{{ item.title_resolved }} <i class="right triangle icon"></i>
+            <div class="ui dropdown {% if item.is_current or item.in_current_branch %}active{% endif %} item">
+                {% block title_dropdown %}{{ item.title_resolved }}{% endblock title_dropdown %}
+                <i class="right triangle icon"></i>
                 {% sitetree_children of item for menu template "sitetree/menu_semantic_dropdown.html" %}
             </div>
         {% else %}
-            <a href="{% sitetree_url for item %}" class="{% if item.is_current or item.in_current_branch %}active{% endif %} item">{{ item.title_resolved }}</a>
+            <a href="{% sitetree_url for item %}" class="{% if item.is_current or item.in_current_branch %}active{% endif %} item">
+                {% block title %}{{ item.title_resolved }}{% endblock title %}
+            </a>
         {% endif %}
     {% endfor %}
 </div>

--- a/sitetree/templates/sitetree/menu_semantic.html
+++ b/sitetree/templates/sitetree/menu_semantic.html
@@ -1,10 +1,14 @@
 {% load sitetree %}
 {% for item in sitetree_items %}
     {% if item.has_children %}
-        <div class="ui dropdown {% if item.is_current or item.in_current_branch %}active{% endif %} item">{{ item.title_resolved }} <i class="dropdown icon"></i>
+        <div class="ui dropdown {% if item.is_current or item.in_current_branch %}active{% endif %} item">
+            {% block title_dropdown %}{{ item.title_resolved }}{% endblock title_dropdown %}
+            <i class="dropdown icon"></i>
             {% sitetree_children of item for menu template "sitetree/menu_semantic_dropdown.html" %}
         </div>
     {% else %}
-        <a href="{% sitetree_url for item %}" class="{% if item.is_current or item.in_current_branch %}active{% endif %} item">{{ item.title_resolved }}</a>
+        <a href="{% sitetree_url for item %}" class="{% if item.is_current or item.in_current_branch %}active{% endif %} item">
+            {% block title %}{{ item.title_resolved }}{% endblock title %}
+        </a>
     {% endif %}
 {% endfor %}

--- a/sitetree/templates/sitetree/menu_semantic_dropdown.html
+++ b/sitetree/templates/sitetree/menu_semantic_dropdown.html
@@ -1,6 +1,8 @@
 {% load sitetree %}
 <div class="menu">
     {% for item in sitetree_items %}
-        <a href="{% sitetree_url for item %}" class="{% if item.is_current or item.in_current_branch %}active{% endif %} item" {% if item.hint %}title="{{ item.hint }}"{% endif %}>{{ item.title_resolved }}</a>
+        <a href="{% sitetree_url for item %}" class="{% if item.is_current or item.in_current_branch %}active{% endif %} item" {% if item.hint %}title="{{ item.hint }}"{% endif %}>
+            {% block title %}{{ item.title_resolved }}{% endblock title %}
+        </a>
     {% endfor %}
 </div>

--- a/sitetree/templates/sitetree/tree.html
+++ b/sitetree/templates/sitetree/tree.html
@@ -4,7 +4,9 @@
 	{% for item in sitetree_items %}
 		{% if item.insitetree  %}
 			<li>
-				<a href="{% sitetree_url for item %}" {% if item.hint %}title="{{ item.hint }}"{% endif %}>{{ item.title_resolved }}</a>
+				<a href="{% sitetree_url for item %}" {% if item.hint %}title="{{ item.hint }}"{% endif %}>
+					{% block title %}{{ item.title_resolved }}{% endblock title %}
+				</a>
 				{% if item.has_children %}
 					{% sitetree_children of item for sitetree template "sitetree/tree.html" %}
 				{% endif %}


### PR DESCRIPTION
This is my take on #305 - I tried to make the templates overridable in order for user to be able to add `|safe` easily.

I don't need this solution now, because my `menu_bootstrap5.html` template is too far from the original anyway. But other users might appreciate this.

I did include some documentation.

@idlesign What do you think of this? Do you want this approach or do you want to choose something different?

